### PR TITLE
[MAINT]: Add CODEOWNERS, issue/PR templates, and update README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @microsoft/ai-red-team-dev

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Install RAMPART v...
+        2. Create a test file with...
+        3. Run `pytest ...`
+        4. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: python-version
+    attributes:
+      label: Python version
+      options:
+        - "3.11"
+        - "3.12"
+        - "3.13"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: rampart-version
+    attributes:
+      label: RAMPART version
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, stack traces, or any other relevant information.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,6 +47,7 @@ body:
         - "3.11"
         - "3.12"
         - "3.13"
+        - "Other"
     validations:
       required: true
 
@@ -68,6 +69,15 @@ body:
       placeholder: "0.1.0"
     validations:
       required: true
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Code to reproduce
+      description: Minimal code snippet that reproduces the issue.
+      render: python
+    validations:
+      required: false
 
   - type: textarea
     id: context

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerabilities
+    url: https://github.com/microsoft/RAMPART/blob/main/.github/SECURITY.md
+    about: Do not report security vulnerabilities through public GitHub issues. See SECURITY.md for reporting guidance.

--- a/.github/ISSUE_TEMPLATE/doc_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.yml
@@ -1,0 +1,19 @@
+name: Documentation Improvement
+description: Report confusing or missing documentation
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is confusing or missing?
+      description: Tell us what's unclear, incorrect, or absent in the docs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: How could the documentation be improved?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Brief description of the feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this feature needed? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the desired outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative approaches you've thought about.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other relevant information, references, or examples.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,11 @@
+name: Other
+description: General issue that doesn't fit other categories
+labels: ["triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe your issue, question, or suggestion.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,21 @@
+<!-- This repository loosely follows the "Conventional Commits" specification for commit messages. See https://www.conventionalcommits.org/ for more information. -->
+<!-- PR commit messages must follow the following pattern: ^\[(FEAT|FIX|REFACTOR|STYLE|TEST|DOCS|CI|MAINT|META|REVERT)\]( \[BREAKING\])?:\s.+\(#\d+\) -->
+<!-- If your PR is not yet ready for review, please mark it as [DRAFT]. -->
+
+## Description
+
+<!-- What does this PR do? Provide a brief summary of the changes. -->
+<!-- Mention any relevant issues or pull requests with #<issue_number> -->
+<!-- Tag any relevant reviewers or teams using @<username> -->
+
+
+## Breaking changes
+<!-- Does this PR introduce breaking changes? If so, describe the impact and migration path. -->
+
+None
+
+## Checklist
+
+- [ ] `pre-commit run --all-files` passes
+- [ ] Tests added or updated for changes <!-- Please describe what tests were added or updated -->
+- [ ] Documentation updated

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,5 +1,6 @@
 <!-- This repository loosely follows the "Conventional Commits" specification for commit messages. See https://www.conventionalcommits.org/ for more information. -->
-<!-- PR commit messages must follow the following pattern: ^\[(FEAT|FIX|REFACTOR|STYLE|TEST|DOCS|CI|MAINT|META|REVERT)\]( \[BREAKING\])?:\s.+\(#\d+\) -->
+<!-- Squash-merge commit messages must match: ^\[(FEAT|FIX|REFACTOR|STYLE|TEST|DOCS|CI|MAINT|META|REVERT)\]( \[BREAKING\])?:\s.+\(#\d+\) -->
+<!-- GitHub appends (#N) automatically during squash-merge; just use the [TAG]: description format for your PR title. -->
 <!-- If your PR is not yet ready for review, please mark it as [DRAFT]. -->
 
 ## Description
@@ -10,9 +11,7 @@
 
 
 ## Breaking changes
-<!-- Does this PR introduce breaking changes? If so, describe the impact and migration path. -->
-
-None
+<!-- If none, write "None". If breaking, describe the impact and migration path. -->
 
 ## Checklist
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 </p>
 
 <p align="center">
-  <a href="https://scorecard.dev/viewer/?uri=github.com/microsoft/RAMPART"><img src="https://api.securityscorecards.dev/projects/github.com/microsoft/RAMPART/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/microsoft/RAMPART"><img src="https://api.securityscorecards.dev/projects/github.com/microsoft/RAMPART/badge" alt="OpenSSF Scorecard"></a> <!-- Will enable once the repository is public -->
   <a href="https://github.com/microsoft/RAMPART/actions/workflows/ci.yml"><img src="https://github.com/microsoft/RAMPART/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://pypi.org/project/RAMPART/"><img src="https://img.shields.io/pypi/v/RAMPART" alt="PyPI"></a>
-  <a href="https://pypi.org/project/RAMPART/"><img src="https://img.shields.io/pypi/pyversions/RAMPART" alt="Python versions"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <!-- <a href="https://pypi.org/project/RAMPART_PYPI_PKG_NAME_TBD/"><img src="https://img.shields.io/pypi/v/RAMPART_PYPI_PKG_NAME_TBD" alt="PyPI"></a> -->
+  <!-- <a href="https://pypi.org/project/RAMPART_PYPI_PKG_NAME_TBD/"><img src="https://img.shields.io/pypi/pyversions/RAMPART_PYPI_PKG_NAME_TBD" alt="Python versions"></a> -->
+  <!-- <a href="https://pypi.org/project/RAMPART_PYPI_PKG_NAME_TBD/"><img src="https://img.shields.io/pypi/l/RAMPART_PYPI_PKG_NAME_TBD" alt="License"></a> -->
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,9 +2,22 @@
   <img src="docs/images/RAMPART.png" alt="RAMPART Logo" width="400"/>
 </p>
 
-# RAMPART: Risk Assessment & Measurement Platform for Agentic Red Teaming
+<h1 align="center">RAMPART</h1>
+<h3 align="center">Risk Assessment & Measurement Platform for Agentic Red Teaming</h3>
 
-**A pytest-native safety and security testing framework for agentic AI applications.**
+<p align="center">
+  <strong>A pytest-native safety and security testing framework for agentic AI applications.</strong>
+</p>
+
+<p align="center">
+  <a href="https://scorecard.dev/viewer/?uri=github.com/microsoft/RAMPART"><img src="https://api.securityscorecards.dev/projects/github.com/microsoft/RAMPART/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://github.com/microsoft/RAMPART/actions/workflows/ci.yml"><img src="https://github.com/microsoft/RAMPART/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://pypi.org/project/RAMPART/"><img src="https://img.shields.io/pypi/v/RAMPART" alt="PyPI"></a>
+  <a href="https://pypi.org/project/RAMPART/"><img src="https://img.shields.io/pypi/pyversions/RAMPART" alt="Python versions"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+</p>
+
+---
 
 RAMPART provides a structured, developer-friendly way to write and run safety and security tests for AI agents -- covering **adversarial attacks**, **benign failures**, and a broad range of **harm categories**, all with evaluation-driven assertions and seamless integration with [pytest](https://docs.pytest.org/).
 


### PR DESCRIPTION
## Description

Add community health files and update README with badges and improved formatting.

**CODEOWNERS** (`.github/CODEOWNERS`):
- Assigns `@microsoft/ai-red-team-dev` as default reviewers for all files

**Issue templates** (`.github/ISSUE_TEMPLATE/`):
- `bug_report.yml` structured form with description, repro steps, expected/actual
  behavior, Python version, OS, and RAMPART version fields
- `feature_request.yml` summary, motivation, proposed solution, alternatives, context
- `config.yml` disables blank issues to enforce template usage
- `doc_improvement.yml` documentation improvement request template
- `other.yml` catch-all template for issues that do not fit other categories

**PR template** (`.github/PULL_REQUEST_TEMPLATE/`):
- Description, breaking changes, and checklist sections
- Header comments documenting the conventional commit pattern for squash messages

**README** (`README.md`):
- Centered title and subtitle
- Badge row:
  - OpenSSF Scorecard (on public access)
  - CI status
  - PyPI version, Python versions, MIT license (all derived from PyPI, dependent on pkg name)

## Breaking changes

None

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Tests added or updated for changes <!-- N/A -- community/docs files only -->
- [x] Documentation updated