### PR TITLE
MAINT added style-guide and unit-tests guide to the instruction set

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,43 @@
+# RAMPART — Repository Instructions
+
+RAMPART is a pytest-native safety testing framework for agentic AI applications.
+
+## Architecture
+
+RAMPART is organized as a modular framework with these main components:
+
+- **Core** (`rampart/core/`) — Foundational types, protocols, and execution logic: `adapter`, `converter`, `evaluator`, `execution`, `injection`, `llm`, `manifest`, `persona`, `prompt_driver`, `result`, `types`.
+- **Probes** (`rampart/probes/`) — Test execution strategies (e.g., single-turn probes).
+- **Attacks** (`rampart/attacks/`) — Attack implementations (e.g., XPIA cross-prompt injection).
+- **Evaluators** (`rampart/evaluators/`) — Response evaluation: `response_contains`, `side_effect`, `tool_called`.
+- **Drivers** (`rampart/drivers/`) — Prompt delivery drivers (e.g., static driver).
+- **Converters** (`rampart/converters/`) — Prompt format converters (e.g., DOCX).
+- **Surfaces** (`rampart/surfaces/`) — Attack surface integrations (e.g., OneDrive).
+- **Payloads** (`rampart/payloads/`) — Payload generation, storage, and templating.
+- **Reporting** (`rampart/reporting/`) — Test result reporting (JSON file sink).
+- **Pytest Plugin** (`rampart/pytest_plugin/`) — Native pytest integration for test collection and session management.
+- **PyRIT Bridge** (`rampart/_pyrit/`) — Isolated boundary for all PyRIT framework interaction (see coding standards for import rules).
+
+## Instruction Files
+
+BEFORE editing or code-reviewing any file, you MUST read the `.github/instructions/` files whose `applyTo` patterns match the files you are about to edit:
+- Editing/code-reviewing `**/*.py` → read `coding-standards.instructions.md`
+- Editing/code-reviewing `**/tests/**` → also read `unit-tests-standards.instructions.md`
+
+Follow every rule in the applicable instruction files. Do not skip this step.
+
+## Code Review Guidelines
+
+When performing a code review, be selective. Only leave comments for issues that genuinely matter:
+
+- Bugs, logic errors, or security concerns
+- Unclear code that would benefit from refactoring for readability
+- Violations of the critical coding conventions (async suffix, keyword-only args, type annotations)
+
+Do NOT leave comments about:
+- Style nitpicks that ruff would catch automatically
+- Missing docstrings or comments — code should be self-explanatory
+- Suggestions to add inline comments, logging, or error handling that isn't clearly needed
+- Minor naming preferences or subjective "improvements"
+
+Aim for fewer, higher-signal comments. A review with 2-3 important comments is better than 15 trivial ones.

--- a/.github/instructions/coding-standards.instructions.md
+++ b/.github/instructions/coding-standards.instructions.md
@@ -6,12 +6,22 @@ applyTo: '**/*.py'
 
 Follow these coding standards to ensure consistent, readable, and maintainable code across the project.
 
+## Copyright Header
+
+- **MANDATORY**: Every `.py` source file MUST begin with the two-line copyright notice
+- This is enforced by ruff's copyright rule (`[tool.ruff.lint.flake8-copyright]`) in `pyproject.toml`
+
+```python
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+```
+
 ## Imports
 
 ### Placement & Organization
 - **MANDATORY**: All import statements MUST be at the top of the file
 - Do NOT use inline/local imports inside functions or methods
-- The only exception is breaking circular import dependencies, which should be rare and documented
+- Exceptions: breaking circular import dependencies (should be rare and documented) and deferring heavy import chains (see [PyRIT Boundary Isolation](#pyrit-boundary-isolation))
 - Use `from __future__ import annotations` when needed for forward references
 - Use `TYPE_CHECKING` guards for imports only needed by type checkers
 
@@ -246,12 +256,6 @@ Order members within a class as follows:
 5. Protected/private methods (prefixed with `_`)
 6. Static/class methods
 
-## Error Handling
-
-- Define a small set of domain-specific exceptions for distinct failure modes
-- Use `raise ... from original` to preserve exception chains
-- Validate inputs in `__post_init__` or at system boundaries; do not over-validate internally
-
 ### Class-Level Constants
 - Define constants as class attributes, not module-level
 - Use UPPER_CASE naming for constants
@@ -307,30 +311,6 @@ async def execute_task_async(self, *, context: TaskContext) -> TaskResult:
 5. Private methods (internal implementation)
 6. Static methods and class methods at the end
 
-### Import Organization
-```python
-# Standard library imports
-import asyncio
-import json
-import logging
-from dataclasses import dataclass
-from enum import Enum
-from pathlib import Path
-from typing import Dict, List, Optional
-
-# Third-party imports
-import numpy as np
-from tqdm import tqdm
-
-# Local application imports
-from myapp.services.base import BaseService
-from myapp.models import TaskResult
-from myapp.clients import ServiceClient
-```
-
-Unless necessary, always import at the top of the file. Don't import inside a function or method.
-
-
 ### Import paths
 
 When importing from a different module than your namespace,
@@ -363,6 +343,10 @@ from myapp.clients.grpc.grpc_client import GrpcClient
 ```
 
 ## Error Handling
+
+- Define a small set of domain-specific exceptions for distinct failure modes
+- Use `raise ... from original` to preserve exception chains
+- Validate inputs in `__post_init__` or at system boundaries; do not over-validate internally
 
 ### Specific Exceptions
 - Raise specific exceptions with clear messages
@@ -446,6 +430,24 @@ async def temporary_config(self, **kwargs):
         yield
     finally:
         self._config = old_config
+```
+
+### Async Context Manager Protocols
+- `__aenter__` MUST return `Self`
+- `__aexit__` MUST be idempotent and MUST NOT raise — log warnings for cleanup failures instead
+- Use `AsyncExitStack` when managing multiple async resources
+
+```python
+# CORRECT
+async def __aenter__(self) -> Self:
+    self._session = await self._create_session()
+    return self
+
+async def __aexit__(self, *exc: object) -> None:
+    try:
+        await self._session.close()
+    except Exception:  # noqa: BLE001
+        logger.warning("cleanup failed", exc_info=True)
 ```
 
 ### Property Decorators
@@ -532,6 +534,39 @@ def process_large_dataset(self, *, file_path: Path) -> List[Result]:
     return [self._process_line(line) for line in lines]
 ```
 
+## Logging Conventions
+
+- Use `logger = logging.getLogger(__name__)` at module level
+- Use `%s`-style lazy formatting in log calls — do NOT use f-strings
+- Use `exc_info=True` when logging errors to preserve stack traces
+- Swallow cleanup errors with a warning log rather than re-raising
+
+```python
+# CORRECT
+logger = logging.getLogger(__name__)
+
+logger.info("Saved %d payloads to '%s'", len(payloads), name)
+logger.warning("Cleanup error during %s: %s", self.name, exc, exc_info=True)
+
+# INCORRECT
+logger.info(f"Saved {len(payloads)} payloads to '{name}'")
+```
+
+## PyRIT Boundary Isolation
+
+- **All PyRIT interaction MUST be isolated to `rampart/_pyrit/`**
+- Do NOT import PyRIT modules from anywhere else in the codebase (except `rampart/converters/` for converter wrappers)
+- PyRIT's import chain is heavy (~14s) — use lazy imports inside functions when wrapping PyRIT converters to defer the cost
+
+```python
+# CORRECT — lazy import in a converter wrapper
+def _get_converter(self) -> WordDocConverter:
+    """PyRIT's import chain is heavy (~14s), so defer until first use."""
+    from pyrit.prompt_converter.word_doc_converter import WordDocConverter  # noqa: PLC0415
+
+    return WordDocConverter()
+```
+
 ## Final Checklist
 
 Before committing code, ensure:
@@ -545,6 +580,9 @@ Before committing code, ensure:
 - [ ] Code follows the import organization pattern
 - [ ] No hard-coded dependencies
 - [ ] Complex logic is extracted to helper methods
+- [ ] Copyright header is present
+- [ ] Log calls use `%s`-style formatting (no f-strings)
+- [ ] PyRIT imports are isolated to `rampart/_pyrit/` (or lazy in converters)
 
 ---
 

--- a/.github/instructions/coding-standards.instructions.md
+++ b/.github/instructions/coding-standards.instructions.md
@@ -1,0 +1,560 @@
+---
+applyTo: '**/*.py'
+---
+
+# Python Coding Style Guidelines
+
+Follow these coding standards to ensure consistent, readable, and maintainable code across the project.
+
+## Imports
+
+### Placement & Organization
+- **MANDATORY**: All import statements MUST be at the top of the file
+- Do NOT use inline/local imports inside functions or methods
+- The only exception is breaking circular import dependencies, which should be rare and documented
+- Use `from __future__ import annotations` when needed for forward references
+- Use `TYPE_CHECKING` guards for imports only needed by type checkers
+
+```python
+# CORRECT
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from mypackage.core import BaseProcessor, Config, Result
+
+if TYPE_CHECKING:
+    from mypackage.models import AppManifest
+```
+
+### Grouping
+Imports are organized in three groups separated by blank lines:
+1. Standard library
+2. Third-party packages
+3. Local application imports
+
+Use parenthesized multi-line imports when importing 3+ names from the same module.
+
+## Function and Method Naming
+
+### Async Functions
+- **MANDATORY**: All async functions and methods MUST end with `_async` suffix
+- This applies to ALL async functions without exception
+
+```python
+# CORRECT
+async def send_request_async(self, *, payload: str) -> Response:
+    ...
+
+# INCORRECT
+async def send_request(self, *, payload: str) -> Response:
+    ...
+```
+
+### Private Methods
+- Private methods MUST start with underscore
+- This clearly indicates internal implementation details
+
+```python
+# CORRECT
+def _validate_input(self, data: dict[str, Any]) -> None:
+    ...
+
+# INCORRECT
+def validate_input(self, data: dict[str, Any]) -> None:
+    ...
+```
+
+## Type Annotations
+
+### Mandatory Type Hints
+- **EVERY** function parameter MUST have explicit type declaration
+- **EVERY** function MUST declare its return type
+- Use `None` for functions that don't return a value
+- Prefer modern union syntax (`str | None`) over `Optional[str]`
+- Use built-in generics (`list[str]`, `dict[str, Any]`) over `typing.List`, `typing.Dict`
+
+```python
+# CORRECT
+def process_items(self, *, items: list[str], limit: int = 10) -> dict[str, Any]:
+    ...
+
+# INCORRECT
+def process_items(self, items, limit=10):
+    ...
+```
+
+## Function Signatures
+
+### Keyword-Only Arguments
+- Functions with more than 1 parameter MUST use `*` after self/cls to enforce keyword-only arguments
+- This prevents positional argument errors and improves API clarity
+
+```python
+# CORRECT
+def __init__(
+    self,
+    *,
+    client: ServiceClient,
+    config: Config,
+    max_retries: int = 3,
+) -> None:
+    ...
+
+# INCORRECT
+def __init__(self, client: ServiceClient, config: Config, max_retries: int = 3):
+    ...
+```
+
+### Single Parameter Functions
+- Functions with only one parameter don't need keyword-only enforcement
+
+```python
+# CORRECT
+def process(self, data: str) -> str:
+    ...
+```
+
+## Data Structures
+
+### Dataclasses
+- Use `@dataclass(kw_only=True)` for classes with multiple fields
+- Use `field(default_factory=...)` for mutable defaults
+- Use `__post_init__` for validation
+
+```python
+@dataclass(kw_only=True)
+class Record:
+    content: str
+    id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    format: RecordFormat = RecordFormat.TEXT
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.content:
+            raise ValueError("content must not be empty")
+```
+
+### Protocols
+- Use `@runtime_checkable` protocols to define interfaces
+- Prefer protocols over abstract base classes when no shared implementation is needed
+
+```python
+@runtime_checkable
+class Handler(Protocol):
+    async def handle_async(self, *, context: Context) -> Result:
+        ...
+```
+
+## Documentation Standards
+
+### No Banner / Separator Comments
+- **MANDATORY**: Do NOT add decorative banner or separator comments
+- This includes comment blocks like `# ----------`, `# ============`, or any variation using repeated characters to form horizontal rules
+
+```python
+# INCORRECT
+# ============================================================================
+# Utility Functions
+# ============================================================================
+
+# CORRECT
+# Utility Functions
+```
+
+### Docstring Format
+- Use Google-style docstrings
+- Include type information in parameter descriptions
+- Document return types and values
+- Include "Raises" section when applicable
+- Use triple quotes even for single-line docstrings
+- Do not include example calls for how it's used
+
+```python
+async def process_async(
+    self,
+    *,
+    context: Context,
+    timeout: float = 30.0,
+) -> Result:
+    """
+    Process the request and return a result.
+
+    Args:
+        context (Context): The processing context with input data.
+        timeout (float): Maximum seconds to wait. Defaults to 30.0.
+
+    Returns:
+        Result: The processing result with status and output.
+
+    Raises:
+        ValueError: If context is missing required fields.
+        TimeoutError: If processing exceeds the timeout.
+    """
+```
+
+## Enums and Constants
+
+### Use Enums Over Literals
+- Use `Enum` for categorical types and `StrEnum` when string interoperability is needed
+- Always use Enum classes instead of `Literal` types for predefined choices
+
+```python
+# CORRECT
+from enum import Enum, StrEnum
+
+class Status(Enum):
+    PENDING = "pending"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+class Category(StrEnum):
+    NETWORK = "network"
+    STORAGE = "storage"
+
+# INCORRECT
+from typing import Literal
+
+def classify(self, *, status: Literal["pending", "complete", "failed"]) -> None:
+    ...
+```
+
+## Module Exports
+
+- Use `__all__` in `__init__.py` files to curate the public API
+- Keep `__all__` entries sorted alphabetically
+
+```python
+from mypackage.handlers.file_handler import FileHandler
+from mypackage.handlers.stream_handler import StreamHandler
+
+__all__ = [
+    "FileHandler",
+    "StreamHandler",
+]
+```
+
+## Class Organization
+
+Order members within a class as follows:
+1. Class-level constants
+2. `__init__`
+3. Public properties (`@property`)
+4. Public methods
+5. Protected/private methods (prefixed with `_`)
+6. Static/class methods
+
+## Error Handling
+
+- Define a small set of domain-specific exceptions for distinct failure modes
+- Use `raise ... from original` to preserve exception chains
+- Validate inputs in `__post_init__` or at system boundaries; do not over-validate internally
+
+### Class-Level Constants
+- Define constants as class attributes, not module-level
+- Use UPPER_CASE naming for constants
+
+```python
+# CORRECT
+class DataProcessor(BaseProcessor):
+    DEFAULT_BATCH_SIZE: int = 32
+    DEFAULT_MAX_RETRIES: int = 5
+    MIN_CONFIDENCE_THRESHOLD: float = 0.7
+
+# INCORRECT
+DEFAULT_BATCH_SIZE = 32  # Should be inside class
+DEFAULT_MAX_RETRIES = 5
+MIN_CONFIDENCE_THRESHOLD = 0.7
+```
+
+## Code Organization
+
+### Function Length
+- Keep functions under 20 lines where possible
+- Extract complex logic into well-named helper methods
+- Each function should have a single, clear responsibility
+
+```python
+# CORRECT
+async def execute_task_async(self, *, context: TaskContext) -> TaskResult:
+    """Execute the task with the given context."""
+    self._validate_context(context)
+
+    prompt = await self._prepare_prompt_async(context)
+    response = await self._send_request_async(prompt, context)
+    result = self._evaluate_response(response, context)
+
+    return result
+
+def _validate_context(self, context: TaskContext) -> None:
+    """Validate the task context."""
+    if not context.objective:
+        raise ValueError("Context must have an objective")
+
+# INCORRECT - Too long and doing too many things
+async def execute_task_async(self, *, context: TaskContext) -> TaskResult:
+    # 50+ lines of mixed validation, preparation, sending, and evaluation logic
+    ...
+```
+
+### Method Ordering
+1. Class-level constants and class variables
+2. `__init__` method
+3. Public methods (API)
+4. Protected methods (subclass API)
+5. Private methods (internal implementation)
+6. Static methods and class methods at the end
+
+### Import Organization
+```python
+# Standard library imports
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Third-party imports
+import numpy as np
+from tqdm import tqdm
+
+# Local application imports
+from myapp.services.base import BaseService
+from myapp.models import TaskResult
+from myapp.clients import ServiceClient
+```
+
+Unless necessary, always import at the top of the file. Don't import inside a function or method.
+
+
+### Import paths
+
+When importing from a different module than your namespace,
+import from the package root if the symbol is exposed from `__init__.py`.
+
+In the same module, importing from the specific path is usually necessary to prevent circular imports.
+
+- Always check `__init__.py` exports first - Before using a specific file path, verify if the class/function is exposed at a higher level
+- Group related imports - Put all imports from the same root module together
+- Use multi-line formatting for readability - When importing 3+ items from the same module, use parentheses
+
+
+```python
+# Correct - importing from package root
+from myapp.clients import HttpClient, GrpcClient
+
+# Correct - multi-line for many imports
+from myapp.validators import (
+    EmailValidator,
+    SchemaValidator,
+    RangeValidator,
+    TypeValidator,
+    FormatValidator,
+)
+
+# Incorrect (if exposed from package root)
+from myapp.clients.http.http_client import HttpClient
+from myapp.clients.grpc.grpc_client import GrpcClient
+
+```
+
+## Error Handling
+
+### Specific Exceptions
+- Raise specific exceptions with clear messages
+- Create custom exceptions when appropriate
+- Always include helpful context in error messages
+
+```python
+# CORRECT
+if not self._model:
+    raise ValueError(
+        "Model not initialized. Call initialize() before executing the task."
+    )
+
+# INCORRECT
+if not self._model:
+    raise Exception("Error")  # Too generic, unhelpful message
+```
+
+### Early Returns
+- Use early returns to reduce nesting
+- Handle edge cases at the beginning of functions
+
+```python
+# CORRECT
+def process_items(self, *, items: List[str]) -> List[str]:
+    if not items:
+        return []
+
+    if len(items) == 1:
+        return [self._process_single(items[0])]
+
+    # Main logic for multiple items
+    return [self._process_single(item) for item in items]
+
+# INCORRECT - Excessive nesting
+def process_items(self, *, items: List[str]) -> List[str]:
+    if items:
+        if len(items) == 1:
+            return [self._process_single(items[0])]
+        else:
+            return [self._process_single(item) for item in items]
+    else:
+        return []
+```
+
+## Pythonic Patterns
+
+### List Comprehensions
+- Use comprehensions for simple transformations
+- Don't use comprehensions for complex logic or side effects
+
+```python
+# CORRECT
+filtered_scores = [s for s in scores if s.value > threshold]
+
+# INCORRECT - Too complex for comprehension
+results = [
+    self._complex_transform(item, index, context)
+    for index, item in enumerate(items)
+    if self._should_process(item, context) and not item.processed
+]
+```
+
+### Context Managers
+- Use context managers for resource management
+- Create custom context managers when appropriate
+
+```python
+# CORRECT
+async with self._get_client() as client:
+    response = await client.send(request)
+
+# For custom resources
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def temporary_config(self, **kwargs):
+    old_config = self._config.copy()
+    self._config.update(kwargs)
+    try:
+        yield
+    finally:
+        self._config = old_config
+```
+
+### Property Decorators
+- Use @property for simple computed attributes
+- Use explicit getter/setter methods for complex logic
+
+```python
+# CORRECT
+@property
+def is_complete(self) -> bool:
+    """Check if the task is complete."""
+    return self._status == TaskStatus.COMPLETE
+
+# INCORRECT - Too complex for property
+@property
+def analysis_report(self) -> str:
+    # 20+ lines of complex report generation
+    ...
+```
+
+## Testing Considerations
+
+### Dependency Injection
+- Design classes to accept dependencies through constructor
+- Avoid hard-coded dependencies
+- For default behaviors, use factory class methods
+
+```python
+# CORRECT
+class TaskExecutor:
+    def __init__(
+        self,
+        *,
+        client: ServiceClient,
+        scorer: Scorer,
+        logger: Optional[logging.Logger] = None
+    ) -> None:
+        self._client = client
+        self._scorer = scorer
+        self._logger = logger or logging.getLogger(__name__)
+
+# INCORRECT
+class TaskExecutor:
+    def __init__(self):
+        self._client = HttpClient()  # Hard-coded dependency
+        self._scorer = DefaultScorer()  # Hard-coded dependency
+```
+
+### Pure Functions
+- Prefer pure functions where possible
+- Separate I/O from business logic
+
+```python
+# CORRECT
+def calculate_score(response: str, objective: str) -> float:
+    """Pure function for score calculation."""
+    # Logic without side effects
+    return score
+
+async def evaluate_response_async(self, *, response: str) -> Score:
+    """I/O function that uses the pure function."""
+    score_value = calculate_score(response, self._objective)
+    await self._save_score_async(score_value)
+    return Score(value=score_value)
+```
+
+## Performance Considerations
+
+### Lazy Evaluation
+- Use generators for large sequences
+- Don't load entire datasets into memory unnecessarily
+
+```python
+# CORRECT
+def process_large_dataset(self, *, file_path: Path) -> Generator[Result, None, None]:
+    with open(file_path) as f:
+        for line in f:
+            yield self._process_line(line)
+
+# INCORRECT
+def process_large_dataset(self, *, file_path: Path) -> List[Result]:
+    with open(file_path) as f:
+        lines = f.readlines()  # Loads entire file into memory
+    return [self._process_line(line) for line in lines]
+```
+
+## Final Checklist
+
+Before committing code, ensure:
+- [ ] All async functions have `_async` suffix
+- [ ] All functions have complete type annotations
+- [ ] Functions with >1 parameter use keyword-only arguments
+- [ ] Docstrings include parameter types
+- [ ] Enums are used instead of Literals
+- [ ] Functions are focused and under 20 lines
+- [ ] Error messages are helpful and specific
+- [ ] Code follows the import organization pattern
+- [ ] No hard-coded dependencies
+- [ ] Complex logic is extracted to helper methods
+
+---
+
+## File Editing Rules
+
+### Never Use `sed` for File Edits
+- **MANDATORY**: Never use `sed` (or similar stream-editing CLI tools) to modify source files
+- `sed` frequently corrupts files, applies partial edits, or silently fails
+- Always use the editor's built-in replace/edit tools (e.g., `replace_string_in_file`, `multi_replace_string_in_file`) to make targeted, verifiable changes
+
+---
+
+**Remember**: Clean code is written for humans to read. Make your intent clear and your code self-documenting.

--- a/.github/instructions/unit-tests-standards.instructions.md
+++ b/.github/instructions/unit-tests-standards.instructions.md
@@ -6,6 +6,17 @@ applyTo: '**/tests/**'
 
 When generating unit tests, follow these guidelines to ensure consistent, maintainable, and thorough test coverage.
 
+## Relaxed Lint Rules for Tests
+
+The project intentionally disables several lint rules for test files (configured in `pyproject.toml` under `[tool.ruff.lint.per-file-ignores]`). Do **not** enforce these in test code:
+
+- **No docstrings required** — test classes and methods do not need docstrings
+- **No type annotations required** — parameters and return types may omit annotations
+- **Magic values allowed** — inline literals in assertions are fine (no need to extract constants)
+- **Private member access allowed** — tests may access `_private` members directly
+- **Unused arguments allowed** — fixture parameters and stubs may appear unused
+- **Local imports allowed** — imports inside test functions for isolation are acceptable
+
 ## Test Organization
 
 ### File & Class Structure
@@ -60,7 +71,7 @@ def _make_record(*, status: Status = Status.PENDING) -> Record:
 
 ### When to Use Fixtures
 - Use fixtures for shared resources that need setup/teardown (temp files, mock servers)
-- Check `conftest.py` and any shared test utilities before creating new fixtures
+- Check `tests/fixtures.py` and any shared test utilities before creating new fixtures
 - Prefer helper functions over fixtures when no cleanup is required
 
 ## What to Test

--- a/.github/instructions/unit-tests-standards.instructions.md
+++ b/.github/instructions/unit-tests-standards.instructions.md
@@ -1,0 +1,128 @@
+---
+applyTo: '**/tests/**'
+---
+
+# Test Generation Instructions
+
+When generating unit tests, follow these guidelines to ensure consistent, maintainable, and thorough test coverage.
+
+## Test Organization
+
+### File & Class Structure
+- Place tests in `tests/unit/[module]/test_[component].py` mirroring the source tree
+- Group related tests into classes with descriptive names starting with `Test`
+- Each test class should focus on a specific behavior or aspect of the component
+- Test methods MUST have return type annotation `-> None`
+
+```python
+class TestParseConfig:
+    def test_returns_defaults_when_empty(self) -> None:
+        result = parse_config({})
+        assert result.timeout == 30.0
+
+    def test_raises_on_missing_required_field(self) -> None:
+        with pytest.raises(ValueError, match="name is required"):
+            parse_config({"timeout": 10})
+```
+
+### Async Tests
+- Use `@pytest.mark.asyncio` decorator for all async test methods
+- Async test method names MUST end with `_async`
+- Use `AsyncMock` instead of `MagicMock` when mocking async methods
+
+```python
+class TestProcessor:
+    @pytest.mark.asyncio
+    async def test_process_returns_result_async(self) -> None:
+        processor = Processor(client=AsyncMock(return_value="ok"))
+        result = await processor.process_async(data="input")
+        assert result.status == Status.COMPLETE
+```
+
+## Test Data Helpers
+
+### Module-Level Builder Functions
+- Define small private helper functions at the top of test files to build test data
+- Keep helpers minimal — only set the fields the tests care about
+- Prefer these over fixtures when no setup/teardown is needed
+
+```python
+def _make_context(text: str) -> Context:
+    """Build a minimal Context for testing."""
+    return Context(
+        items=[Item(id="test", content=text)],
+    )
+
+def _make_record(*, status: Status = Status.PENDING) -> Record:
+    """Build a Record with sensible defaults."""
+    return Record(id="r1", status=status, metadata={})
+```
+
+### When to Use Fixtures
+- Use fixtures for shared resources that need setup/teardown (temp files, mock servers)
+- Check `conftest.py` and any shared test utilities before creating new fixtures
+- Prefer helper functions over fixtures when no cleanup is required
+
+## What to Test
+
+### Initialization
+- Valid construction with required parameters only
+- Construction with all optional parameters
+- Invalid parameter combinations that should raise exceptions
+- Default value verification
+
+### Core Functionality
+For each public method:
+- Normal operation with valid inputs
+- Boundary conditions and edge cases
+- Return values and side effects
+- State changes after method calls
+
+### Error Handling
+- Invalid input raises the expected exception type
+- Use `pytest.raises` with `match` to verify error messages
+- Exception chaining is preserved (`raise ... from`)
+- Resources are cleaned up on failure
+
+```python
+def test_rejects_negative_timeout(self) -> None:
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        Config(timeout=-1)
+```
+
+## Mocking Best Practices
+
+### Dependency Isolation
+- Mock all external dependencies (APIs, databases, file systems)
+- Mock at the boundary — don't mock internal implementation details
+- Use dependency injection to make mocking straightforward
+
+### Mock Configuration
+```python
+# Async method mock
+mock_client = AsyncMock()
+mock_client.fetch_async.return_value = Response(data="ok")
+
+# Sync method mock
+mock_store = MagicMock()
+mock_store.get.return_value = {"key": "value"}
+
+# Side effects for sequential calls
+mock_client.fetch_async.side_effect = [
+    Response(data="first"),
+    Response(data="second"),
+    ConnectionError("unavailable"),
+]
+```
+
+### Assertion Patterns
+- Use direct `assert` statements — not `self.assertEqual` or similar
+- Use `is` for identity checks (enums, singletons, `None`)
+- Use `==` for value equality
+- One logical assertion per test when practical
+
+```python
+assert result.status is Status.COMPLETE
+assert result.value == 42
+assert "expected substring" in result.message
+```


### PR DESCRIPTION
Adds two `.instructions.md` files under instructions that Copilot uses when generating or suggesting code:

1. `coding-standards.instructions.md` - Python style conventions
1. `unit-tests-standards.instructions.md` - Test conventions