### PR TITLE
[FIX]: Suppress `confusables` invalid escape sequence warnings in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,10 @@ markers = [
     "harm(*categories): categorize test by harm type",
     "trial(n=, threshold=): statistical repetition of a test",
 ]
+filterwarnings = [
+    "ignore:.*invalid escape sequence:DeprecationWarning:.*confusables.*",
+    "ignore:.*invalid escape sequence:SyntaxWarning:.*confusables.*",
+]
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
## Description

On a clean virtual environment (first run, no `.pyc` cache), pytest emits a
`DeprecationWarning` (Python 3.11–3.13) or `SyntaxWarning` (Python 3.14+) from the third-party `confusables` package

This is mainly so CI passes cleanly on first run.

(see [Test (Python 3.11)](https://github.com/microsoft/RAMPART/actions/runs/24558220002/job/71799977552?pr=12) and others) 

``confusables/init.py:46: DeprecationWarning: invalid escape sequence '*'
space_regex = "[*_~|`-.]*" if include_character_padding else``

### Verify

`rm -rf .venv && uv venv --python 3.13 && uv sync --locked && pytest tests` for python 3.11-3.14

## Breaking changes

None

## Checklist

- [X] `pre-commit run --all-files` passes
- [ ] Tests added or updated for changes
- [ ] Documentation updated