### PR TITLE
[CI]: Improve CI and split out coverage as separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   lint:
     name: Lint & Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -48,7 +49,9 @@ jobs:
 
   test:
     name: Test (Python ${{ matrix.python-version }})
+    needs: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     strategy:
@@ -76,5 +79,4 @@ jobs:
         run: uv sync --frozen
 
       - name: Run tests
-        # Coverage threshold (fail_under) is enforced via pyproject.toml [tool.coverage.report]
-        run: uv run pytest tests/unit --cov=rampart --cov-report=xml --cov-report=term-missing
+        run: uv run pytest tests/unit

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,56 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run tests with coverage
+        id: tests
+        # --cov-fail-under=0 overrides pyproject.toml [tool.coverage.report] fail_under
+        # so pytest doesn't exit non-zero on low coverage; threshold is checked separately below.
+        run: uv run pytest tests/unit --cov=rampart --cov-report=term-missing --cov-fail-under=0
+
+      - name: Coverage summary
+        if: ${{ steps.tests.outcome == 'success' }}
+        run: |
+          echo '## Coverage Report' >> $GITHUB_STEP_SUMMARY
+          uv run coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+
+      - name: Check coverage threshold
+        if: ${{ steps.tests.outcome == 'success' }}
+        # Threshold is defined in pyproject.toml [tool.coverage.report] fail_under
+        run: uv run coverage report


### PR DESCRIPTION
## Description

Separates coverage analysis from the CI test workflow into an independent `coverage.yml` workflow, and applies several CI hardening improvements.

**Changes:**

- **Split coverage into `coverage.yml`**: Coverage collection, reporting, and threshold enforcement now run in a dedicated workflow with a single Python 3.12 job, independent from the test matrix. This gives separate status checks in PRs — `CI` for correctness, `Coverage` for quality — enabling independent branch protection policies (e.g., requiring CI but making coverage advisory).

- **Remove `--cov` from test workflow**: The `test` job in `ci.yml` now runs plain `pytest` without coverage instrumentation, simplifying the job and slightly improving test performance.

- **Add `needs: lint` to test job**: Tests now wait for lint to pass before running, avoiding wasted compute on 3 matrix jobs when the code doesn't lint.

- **Add `timeout-minutes: 10` to all jobs**: Prevents hung jobs from consuming runners for the default 6-hour limit.

- **Coverage Job Summary**: The coverage workflow writes a markdown coverage table directly to the GitHub Actions Job Summary page, providing visibility without external services or artifact downloads.

- **Separated failure signals**: Test failures and coverage threshold failures produce distinct step-level signals in the coverage workflow. The threshold is enforced via `pyproject.toml` `[tool.coverage.report] fail_under` (DRY — single source of truth).

## Breaking changes

None. No changes to runtime code, test code, or pyproject.toml configuration. Branch protection rules may need updating to add the new `Coverage` status check if desired.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Tests added or updated for changes <!-- No test changes needed — CI workflow only -->
- [x] Documentation updated <!-- Self-documenting: workflow comments explain non-obvious behaviors -->
