### PR TITLE
[CI]: Add actions language to CodeQL scanning matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [python]
+        language: [actions, python]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Description

Add `actions` to the CodeQL language matrix so GitHub Actions workflow files are scanned for security issues alongside Python.

Previously, only the default setup (enabled via UI) was scanning `actions` — the custom workflow only covered `python`. This ensures full coverage after disabling default setup to eliminate duplicate CodeQL configurations.

Also, the reason the CodeQL workflow was originally failing was due to:

```
Error: Code Scanning could not process the submitted SARIF file:
CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled
```

## Breaking changes
None

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Tests added or updated for changes <!-- N/A — CI config only -->
- [ ] Documentation updated <!-- N/A -->
