### PR TITLE
[CI]: Fix Scorecard permissions for private repository

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,9 +25,13 @@ jobs:
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
+      # Required for private repos to avoid GraphQL/SAST gaps.
+      # See https://github.com/ossf/scorecard-action?tab=readme-ov-file#additional-permissions-for-private-repositories
       contents: read
       actions: read
+      issues: read
+      pull-requests: read
+      checks: read
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
## Description

Add missing `issues: read`, `pull-requests: read`, and `checks: read` permissions to the Scorecard workflow.

Without these, the Scorecard action fails on private repos with:

```
ListCommits: error during graphqlHandler.setup: Resource not accessible by integration
```

The default `GITHUB_TOKEN` in private repos has restricted GraphQL API access. See [scorecard-action docs](https://github.com/ossf/scorecard-action?tab=readme-ov-file#additional-permissions-for-private-repositories).

## Breaking changes
None

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Tests added or updated for changes <!-- N/A — CI config only -->
- [ ] Documentation updated <!-- N/A -->'
