### PR TITLE
[DOCS]: Add Github Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install docs dependencies
+        run: uv sync --only-group docs --frozen
+
+      - name: Build site
+        run: uv run mkdocs build --strict --site-dir _site
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy docs
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -79,7 +79,7 @@ All of the following must pass before a PR can be merged:
 
 ### Tests
 
-- Unit tests pass on Python versions detailed in [pyproject.toml](../../pyproject.toml) and [ci pipelines](https://github.com/microsoft/RAMPART/actions/workflows/ci.yml).
+- Unit tests pass on Python versions detailed in [pyproject.toml](https://github.com/microsoft/RAMPART/blob/main/pyproject.toml) and [ci pipelines](https://github.com/microsoft/RAMPART/actions/workflows/ci.yml).
 
 ### Coverage
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: RAMPART
 site_description: A pytest-native safety testing framework for agentic AI applications
+site_url: https://microsoft.github.io/RAMPART/
 repo_url: https://github.com/microsoft/RAMPART
 repo_name: microsoft/RAMPART
 


### PR DESCRIPTION
## Description

Adds build + publish github workflow for docs.

1. Verifies on PR
2. Publishes on push to main
3. Also allow manual trigger

## Breaking changes
None

## Checklist

- [X] `pre-commit run --all-files` passes
- [ ] Tests added or updated for changes
- [X] Documentation updated
