### PR TITLE
[DOCS]: Add RAMPART acronym, examples repo references, and contributing nav fix

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -8,3 +8,4 @@ description: Install RAMPART, run your first safety test, and learn how the pyte
 |------|-------------|
 | [Installation](installation.md) | Install RAMPART and dependencies |
 | [Quickstart](quickstart.md) | Build your first safety test end-to-end |
+| [RAMPART Examples](https://github.com/microsoft/rampart-examples) | Explore runnable demos |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,6 +2,9 @@
 
 This guide walks you through writing your first RAMPART safety test — from adapter to a passing test run.
 
+!!! tip "Prefer to read working code?"
+    [`microsoft/rampart-examples`](https://github.com/microsoft/rampart-examples) hosts self-contained demos with a complete adapter, manifest, surface, and red → fix → green test walkthrough you can clone and run.
+
 ---
 
 ## Step 1: Install RAMPART
@@ -176,3 +179,4 @@ JSON reports are written to `.report/`.
 - [Writing Tests](../usage/authoring-tests.md) — Adapters, manifests, evaluators, surfaces in depth
 - [pytest Markers & Fixtures](../usage/pytest-integration.md) — `@harm`, `@trial`, `rampart_sinks`
 - [Configuration](../usage/configuration.md) — LLMConfig, Persona, AppManifest
+- [RAMPART Examples](https://github.com/microsoft/rampart-examples) — Runnable demos showing complete adapter + test setups

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -63,6 +63,9 @@ Terms used throughout the RAMPART documentation.
 **PyRIT**
 :   [Python Risk Identification Tool](https://github.com/microsoft/PyRIT). The upstream library RAMPART builds on. See [PyRIT Integration](concepts/pyrit.md).
 
+**RAMPART**
+:   [Risk Assessment & Measurement Platform for Agentic Red Teaming](https://github.com/microsoft/rampart).
+
 **ReportSink**
 :   A destination for test run reports. See [`ReportSink`][rampart.reporting.sink.ReportSink].
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ assert result, result.summary
 | If you want to… | Start here |
 |---|---|
 | Install RAMPART and run your first test | [Getting Started](getting-started/index.md) |
+| Explore runnable, end-to-end demos | [RAMPART Examples](https://github.com/microsoft/rampart-examples) |
 | Understand how RAMPART works | [Concepts](concepts/overview.md) |
 | Write an XPIA attack test | [XPIA Attack](attacks/xpia.md) |
 | Write a behavioral probe | [Behavioral Probe](probes/behavioral.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,9 @@ description: RAMPART is a pytest-native safety testing framework for agentic AI 
 
 # RAMPART Documentation
 
-**RAMPART** is a pytest-native safety testing framework for agentic AI applications. You write tests that attack or probe your agent, and RAMPART orchestrates the interaction, evaluates the outcome, and reports the results.
+**RAMPART**: Risk Assessment & Measurement Platform for Agentic Red Teaming.
+
+RAMPART is a pytest-native safety testing framework for agentic AI applications. You write tests that attack or probe your agent, and RAMPART orchestrates the interaction, evaluates the outcome, and reports the results.
 
 ```python
 result = await Attacks.xpia(
@@ -29,6 +31,7 @@ assert result, result.summary
 | Write an XPIA attack test | [XPIA Attack](attacks/xpia.md) |
 | Write a behavioral probe | [Behavioral Probe](probes/behavioral.md) |
 | Learn testing patterns and best practices | [Usage](usage/index.md) |
+| Contribute back to the project | [Contributing](contributing/index.md) |
 | Look up a class or function | [API Reference](api/index.md) |
 | Find a term definition | [Glossary](glossary.md) |
 


### PR DESCRIPTION
## Description

Two small documentation polish changes for new-user discoverability:

- **Spell out the RAMPART acronym** ("Risk Assessment & Measurement Platform for Agentic Red Teaming") on the landing page and in the glossary, and add the missing link in the Contributing Quick Nav table.
- **Surface the [`microsoft/rampart-examples`](https://github.com/microsoft/rampart-examples) companion repo** from the three places a new user is most likely to land:
  - Home page Quick Navigation gets a "See a runnable, end-to-end demo" row.
  - Getting Started index gets a third row pointing at the demos (e.g. `helpdesk-bot`).
  - Quickstart gets a tip admonition near the top and a bullet under "What''s Next" for readers who prefer working code over walkthroughs.

All edits are confined to `docs/` markdown; `mkdocs build` succeeds with no new warnings on the touched files.

## Breaking changes

None.

## Checklist

- [x] `pre-commit run --all-files` passes (ran on the changed markdown files; no Python files in the diff)
- [ ] Tests added or updated for changes (N/A; documentation-only)
- [x] Documentation updated
