### PR TITLE
[security] fix(payloads): harden payload artifact paths

### DIFF
--- a/rampart/core/payload_ids.py
+++ b/rampart/core/payload_ids.py
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Validation helpers for payload identifiers."""
+
+from __future__ import annotations
+
+import re
+
+_PAYLOAD_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
+def validate_payload_id(payload_id: str) -> None:
+    """Validate that a payload ID is safe to embed in file names.
+
+    Payload IDs are used for local artifact filenames and remote upload
+    names. Keep them to a small cross-platform filename-safe alphabet so
+    generated artifacts cannot introduce path separators, path traversal,
+    control characters, or Graph path-addressing delimiters.
+    """
+    if not _PAYLOAD_ID_PATTERN.fullmatch(payload_id):
+        msg = (
+            f"Invalid payload id: {payload_id!r}. Payload IDs must be 1-128 "
+            "characters using only letters, numbers, '.', '_', and '-'."
+        )
+        raise ValueError(msg)
+
+    if payload_id in {".", ".."}:
+        msg = (
+            f"Invalid payload id: {payload_id!r}. Payload IDs cannot be path segments."
+        )
+        raise ValueError(msg)

--- a/rampart/core/types.py
+++ b/rampart/core/types.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from rampart.core.payload_ids import validate_payload_id
+
 if TYPE_CHECKING:
     from datetime import datetime
     from pathlib import Path
@@ -119,6 +121,7 @@ class Payload:
 
     def __post_init__(self) -> None:
         """Validate content-format-artifact consistency."""
+        validate_payload_id(self.id)
         if self.format.is_binary and self.artifact is None:
             msg = (
                 f"Binary format {self.format.value} requires an "

--- a/rampart/payloads/_store.py
+++ b/rampart/payloads/_store.py
@@ -31,9 +31,11 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from rampart.core.payload_ids import validate_payload_id
 from rampart.core.types import Payload, PayloadFormat
 
 logger = logging.getLogger(__name__)
+_MIN_ARTIFACT_PATH_PARTS = 2
 
 
 class PayloadStore:
@@ -326,10 +328,53 @@ class PayloadStore:
         Returns:
             str: Relative artifact path (e.g., 'artifacts/abc123.pdf').
         """
+        validate_payload_id(payload_id)
         artifacts_dir.mkdir(parents=True, exist_ok=True)
         filename = f"{payload_id}{extension}"
-        shutil.copy2(source, artifacts_dir / filename)
+        destination = artifacts_dir / filename
+        PayloadStore._ensure_within_directory(
+            path=destination,
+            directory=artifacts_dir,
+            description="artifact destination",
+        )
+        shutil.copy2(source, destination)
         return f"artifacts/{filename}"
+
+    @staticmethod
+    def _ensure_within_directory(
+        *,
+        path: Path,
+        directory: Path,
+        description: str,
+    ) -> None:
+        """Raise if a resolved path escapes a required directory."""
+        resolved_path = path.resolve(strict=False)
+        resolved_directory = directory.resolve(strict=False)
+        if not resolved_path.is_relative_to(resolved_directory):
+            msg = f"Invalid {description}: {path!s} escapes {directory!s}"
+            raise ValueError(msg)
+
+    @staticmethod
+    def _resolve_artifact_path(*, collection_dir: Path, artifact: str) -> Path:
+        """Resolve a serialized artifact path inside collection artifacts/."""
+        artifact_path = Path(artifact)
+        if artifact_path.is_absolute() or ".." in artifact_path.parts:
+            msg = f"Invalid artifact path: {artifact!r}. Must stay under artifacts/."
+            raise ValueError(msg)
+        if (
+            len(artifact_path.parts) < _MIN_ARTIFACT_PATH_PARTS
+            or artifact_path.parts[0] != "artifacts"
+        ):
+            msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
+            raise ValueError(msg)
+
+        resolved = collection_dir / artifact_path
+        PayloadStore._ensure_within_directory(
+            path=resolved,
+            directory=collection_dir / "artifacts",
+            description="artifact path",
+        )
+        return resolved
 
     @staticmethod
     def _deserialize(
@@ -354,7 +399,10 @@ class PayloadStore:
 
         artifact: Path | None = None
         if "artifact" in data:
-            artifact_path = collection_dir / data["artifact"]
+            artifact_path = PayloadStore._resolve_artifact_path(
+                collection_dir=collection_dir,
+                artifact=data["artifact"],
+            )
             if not artifact_path.exists():
                 msg = f"Missing artifact: {artifact_path}"
                 raise FileNotFoundError(msg)

--- a/rampart/surfaces/onedrive.py
+++ b/rampart/surfaces/onedrive.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Self
 
 from rampart.core.errors import InfrastructureError
 from rampart.core.injection import sleep_until_ready
+from rampart.core.payload_ids import validate_payload_id
 
 if TYPE_CHECKING:
     import types
@@ -110,6 +111,7 @@ class OneDriveSurface:
                 if the payload exceeds the 4 MiB small-upload limit.
             InfrastructureError: If Graph returns no ``DriveItem``.
         """
+        validate_payload_id(payload.id)
         filename = f"{payload.id}{payload.format.extension}"
         upload_path = f"{self.folder_path}/{filename}"
 

--- a/tests/unit/payloads/test_payload_store_security.py
+++ b/tests/unit/payloads/test_payload_store_security.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Security tests for payload IDs and artifact path handling."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rampart.core.types import Payload, PayloadFormat
+from rampart.payloads._store import PayloadStore
+
+
+@pytest.mark.parametrize(
+    "payload_id",
+    [
+        "",
+        ".",
+        "..",
+        "../outside",
+        "..\\outside",
+        "/tmp/outside",
+        "nested/name",
+        "graph:path",
+        "line\nbreak",
+        "x" * 129,
+    ],
+)
+def test_payload_id_rejects_path_unsafe_values(payload_id: str) -> None:
+    """Payload IDs reject values that can become unsafe path components."""
+    with pytest.raises(ValueError, match="Invalid payload id"):
+        Payload(content="content", id=payload_id)
+
+
+def test_payload_store_keeps_binary_artifacts_under_artifacts_dir(
+    tmp_path: Path,
+) -> None:
+    """Binary payload artifacts are copied beneath the artifacts directory."""
+    source = tmp_path / "source.pdf"
+    source.write_bytes(b"pdf")
+
+    store = PayloadStore(root=tmp_path / "store")
+    payload = Payload(
+        content="binary",
+        id="safe-id_1.2",
+        format=PayloadFormat.PDF,
+        artifact=source,
+    )
+
+    collection_dir = store.save("collection", payloads=[payload])
+
+    expected_artifact = collection_dir / "artifacts" / "safe-id_1.2.pdf"
+    assert expected_artifact.read_bytes() == b"pdf"
+    assert store.load("collection")[0].artifact == expected_artifact
+
+
+def test_payload_store_rejects_deserialized_artifact_traversal(tmp_path: Path) -> None:
+    """Serialized artifact paths cannot traverse outside the collection."""
+    collection_dir = tmp_path / "store" / "collection"
+    collection_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.pdf"
+    outside.write_bytes(b"outside")
+    record: dict[str, object] = {
+        "id": "safe-id",
+        "content": "binary",
+        "format": "pdf",
+        "metadata": {},
+        "artifact": "../outside.pdf",
+    }
+    (collection_dir / "payloads.jsonl").write_text(json.dumps(record) + "\n")
+
+    store = PayloadStore(root=tmp_path / "store")
+    with pytest.raises(ValueError, match="Invalid artifact path"):
+        store.load("collection")
+
+
+def test_payload_store_rejects_deserialized_artifact_symlink_escape(
+    tmp_path: Path,
+) -> None:
+    """Serialized artifact paths cannot resolve through symlinks outside artifacts."""
+    collection_dir = tmp_path / "store" / "collection"
+    artifacts_dir = collection_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.pdf"
+    outside.write_bytes(b"outside")
+    symlink = artifacts_dir / "linked.pdf"
+    symlink.symlink_to(outside)
+    record: dict[str, object] = {
+        "id": "safe-id",
+        "content": "binary",
+        "format": "pdf",
+        "metadata": {},
+        "artifact": "artifacts/linked.pdf",
+    }
+    (collection_dir / "payloads.jsonl").write_text(json.dumps(record) + "\n")
+
+    store = PayloadStore(root=tmp_path / "store")
+    with pytest.raises(ValueError, match="escapes"):
+        store.load("collection")

--- a/tests/unit/surfaces/test_onedrive_security.py
+++ b/tests/unit/surfaces/test_onedrive_security.py
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Security tests for OneDrive payload upload path construction."""
+
+from typing import Any, cast
+
+import pytest
+
+from rampart.core.types import Payload
+from rampart.surfaces.onedrive import OneDriveSurface
+
+
+async def test_onedrive_upload_rejects_unsafe_payload_id_before_graph_call() -> None:
+    """OneDrive upload refuses unsafe filenames before Graph path construction."""
+    payload = Payload(content="content", id="safe-id")
+    payload.id = "../outside"
+    surface = OneDriveSurface(
+        graph_client=cast("Any", object()),
+        drive_id="drive-id",
+        folder_path="folder",
+    )
+
+    with pytest.raises(ValueError, match="Invalid payload id"):
+        await surface.upload_async(payload=payload)


### PR DESCRIPTION
## Summary

This PR hardens how RAMPART handles payload identifiers and persisted payload artifacts before they are embedded into local artifact paths or OneDrive upload names.

Payload IDs and serialized artifact paths are now constrained to filename-safe, collection-local values. The patch rejects unsafe IDs at payload construction time, validates artifact copy destinations before writing, validates deserialized artifact references before loading, and applies the same payload ID boundary before constructing OneDrive upload paths.

## Security issues covered

| Issue | Impact | Fix |
| --- | --- | --- |
| Payload ID path traversal in artifact filenames | A payload ID containing path separators or traversal segments could influence where binary artifacts are written when a collection is saved. | Add shared payload ID validation and destination containment checks before artifact copies. |
| Persisted artifact path escape on load | A crafted `payloads.jsonl` artifact reference could point outside the collection's `artifacts/` directory. | Require relative `artifacts/...` paths, reject `..` and absolute paths, and resolve/contain paths under the collection artifacts directory. |
| OneDrive path-addressing injection via payload ID | A payload ID with path delimiters could be embedded into a Microsoft Graph path-addressed upload name. | Validate the payload ID before constructing the OneDrive upload filename/path. |

## Before this PR

- `Payload.id` values were accepted without a filename/path safety boundary.
- Binary artifact filenames were derived directly from `payload.id`.
- Deserialized artifact paths were joined with the collection directory without first enforcing that they remained under `artifacts/`.
- OneDrive uploads embedded `payload.id` into a Graph path-addressed filename.

## After this PR

- Payload IDs must be 1-128 characters using only letters, numbers, `.`, `_`, and `-`.
- `.` and `..` are rejected explicitly.
- Artifact copy destinations are resolved and checked to remain inside the target `artifacts/` directory.
- Serialized artifact references must be relative `artifacts/...` paths and must not contain traversal segments.
- OneDrive uploads reject unsafe payload IDs before constructing remote paths.

## Why this matters

Payload collections are persisted to disk and may include binary artifacts. If a payload source, generated collection, or persisted JSONL record is treated as data but can influence filesystem paths, it can cross from payload content into host file placement or host file reads.

Enforcing a narrow filename-safe payload ID format and resolving artifact paths under the collection artifact root keeps payload data inside the intended storage boundary.

## Attack flow

```text
1. An unsafe payload ID or crafted payloads.jsonl record is introduced.
2. RAMPART saves or loads a payload collection.
3. The unsafe value is used as part of an artifact path or remote upload path.
4. Without containment checks, the value can escape the intended artifact namespace.
5. With this PR, the unsafe value is rejected before the path is used.
```

## Affected code

- `rampart/core/types.py`
- `rampart/core/payload_ids.py`
- `rampart/payloads/_store.py`
- `rampart/surfaces/onedrive.py`

## Root cause

- Payload IDs were used in file and remote path construction without a shared safety contract.
- Serialized artifact paths were trusted as relative collection-local values without validating traversal, absolute paths, or symlink-mediated escapes.
- Local artifact persistence and remote surface upload construction enforced related path boundaries independently, leaving room for drift.

## CVSS assessment

Issue: payload artifact path containment bypass

CVSS v3.1: 7.1 High

Vector: `CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N`

Rationale: exploitation requires the ability to introduce or load a crafted payload collection or payload definition in the local RAMPART execution context. If reached, the vulnerable path construction can cross the intended artifact boundary and affect confidentiality or integrity of local files addressed by the running process.

## Safe reproduction steps

On vulnerable code, a regression test can construct a payload with an ID containing traversal or load a `payloads.jsonl` record whose `artifact` field points outside `artifacts/`.

Examples covered by the tests in this PR:

```python
Payload(id="../outside", content="x", format=PayloadFormat.TEXT)
```

```json
{"id":"safe","content":"x","format":"text","metadata":{},"artifact":"../outside.pdf"}
```

## Expected vulnerable behavior

Before the fix, unsafe payload IDs or serialized artifact references could reach path construction. Depending on the operation, this could place an artifact outside the expected directory or resolve a loaded artifact reference outside the collection's `artifacts/` root.

After the fix, these inputs raise `ValueError` before file copy, artifact load, or OneDrive path construction proceeds.

## Changes in this PR

- Adds `rampart.core.payload_ids.validate_payload_id()` as the shared payload ID safety boundary.
- Calls the validator from `Payload.__post_init__()` and OneDrive upload path construction.
- Validates artifact copy destinations with resolved-path containment checks.
- Adds a dedicated artifact deserialization resolver that rejects absolute paths, `..`, non-`artifacts/` paths, and symlink escapes.
- Adds regression coverage for unsafe IDs, local artifact copy behavior, artifact traversal, symlink escape handling, and OneDrive upload validation.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Core validation | `rampart/core/payload_ids.py`, `rampart/core/types.py` | Adds and applies shared payload ID validation. |
| Payload persistence | `rampart/payloads/_store.py` | Adds artifact destination and deserialization containment checks. |
| OneDrive surface | `rampart/surfaces/onedrive.py` | Validates payload IDs before Graph path-addressed upload names are built. |
| Regression tests | `tests/unit/payloads/test_payload_store_security.py`, `tests/unit/surfaces/test_onedrive_security.py` | Covers rejected unsafe inputs and allowed safe artifact persistence. |

## Maintainer impact

This is intentionally narrow. Existing payload IDs that already use simple filename-safe IDs continue to work. Payload IDs containing path separators, Graph path delimiters, control characters, empty strings, or traversal-only segments are now rejected early with `ValueError`.

The persisted artifact format remains `artifacts/<filename>` for valid existing collections.

## Fix rationale

The safest boundary is to prevent payload IDs from being path-like at all, then still perform resolved-path containment checks at the filesystem boundary. This keeps the API contract simple while preserving defense in depth for deserialized data that may come from disk.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor only

## Test plan

Commands run locally:

```bash
uv run pytest tests/unit/payloads/test_payload_store_security.py tests/unit/surfaces/test_onedrive_security.py -q
uv run pytest -q
uv run ruff check rampart/core/payload_ids.py rampart/core/types.py rampart/payloads/_store.py rampart/surfaces/onedrive.py tests/unit/payloads/test_payload_store_security.py tests/unit/surfaces/test_onedrive_security.py
uv run ruff format --check rampart/core/payload_ids.py rampart/core/types.py rampart/payloads/_store.py rampart/surfaces/onedrive.py tests/unit/payloads/test_payload_store_security.py tests/unit/surfaces/test_onedrive_security.py
uv run pyright rampart/core/payload_ids.py rampart/core/types.py rampart/payloads/_store.py rampart/surfaces/onedrive.py tests/unit/payloads/test_payload_store_security.py tests/unit/surfaces/test_onedrive_security.py
python -m compileall -q rampart tests
git diff --check
```

Results:

- Focused security tests: `14 passed`
- Full test suite: `462 passed`
- Ruff check: passed
- Ruff format check: passed
- Pyright on touched files/tests: `0 errors, 0 warnings, 0 informations`
- Compileall: passed
- Diff whitespace check: passed

## Disclosure notes

This PR is limited to hardening payload ID and artifact path handling in the local payload store and OneDrive upload path construction. It does not claim to change unrelated payload generation, model behavior, or broader surface authentication semantics.
