### PR TITLE
[DOCS]: expand README with installation, quick start, and documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,40 @@
 
 RAMPART provides a structured, developer-friendly way to write and run safety and security tests for AI agents -- covering **adversarial attacks**, **benign failures**, and a broad range of **harm categories**, all with evaluation-driven assertions and seamless integration with [pytest](https://docs.pytest.org/).
 
+## Installation
+
+```bash
+pip install rampart
+```
+
+## Quick Start
+
+```python
+result = await Attacks.xpia(
+    trigger="Summarize the Q3 reports",
+    evaluator=ToolCalled("send_email"),
+    inject=handle,
+).execute_async(adapter=my_agent)
+
+assert result, result.summary
+```
+
+See [Getting Started](https://microsoft.github.io/RAMPART/getting-started/) for the adapter pattern, installation prerequisites, and a complete first test.
+
+## Documentation
+
+Full documentation lives at **[microsoft.github.io/RAMPART](https://microsoft.github.io/RAMPART/)**:
+
+* [Getting Started](https://microsoft.github.io/RAMPART/getting-started/): first test in 5 minutes
+* [Concepts](https://microsoft.github.io/RAMPART/concepts/overview/): adapters, evaluators, execution model
+* [XPIA Attack](https://microsoft.github.io/RAMPART/attacks/xpia/): cross-platform injection testing
+* [Behavioral Probe](https://microsoft.github.io/RAMPART/probes/behavioral/): agent behaviour assertions
+* [API Reference](https://microsoft.github.io/RAMPART/api/): class and function reference
+
+## Contributing
+
+Contributions are welcome. See the [Contributing Guide](https://microsoft.github.io/RAMPART/contributing/) for development setup, code style, testing standards, and the pull request process. The repository follows the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/) and most contributions require signing the [Microsoft CLA](https://cla.opensource.microsoft.com).
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft


### PR DESCRIPTION
## Description

The current README ships a single descriptive paragraph followed immediately by the Trademarks block, which leaves no on-ramp for someone landing on the GitHub repo. Since v0.1.0 is already published on PyPI, the README ought to surface the install command, a runnable Quick Start, and a navigable map of the docs site.

This PR adds, in order, between the existing description and the Trademarks block:

* **Installation** with the standard `pip install rampart` command.
* **Quick Start** using the canonical XPIA snippet lifted verbatim from `docs/index.md`, so the README example cannot drift from the docs site.
* **Documentation** with a short bullet list pointing at the five key entry points on microsoft.github.io/RAMPART (Getting Started, Concepts, XPIA Attack, Behavioral Probe, API Reference).
* **Contributing** with a one-line pointer to the Contributing Guide plus the Code of Conduct and CLA links.

The Trademarks block moves to the bottom (conventional position).

No code, no tests, no docs site content changed. Each new link target was checked against the on-disk docs tree (`docs/getting-started/index.md`, `docs/concepts/overview.md`, `docs/attacks/xpia.md`, `docs/probes/behavioral.md`, `docs/api/index.md`) and the `mkdocs.yml` nav, so all five links resolve at the published docs site.

## Breaking changes

None.

## Checklist

- [x] \`pre-commit run --all-files\` passes (no Python files changed; ruff and pyright are no-ops on markdown).
- [x] Tests added or updated for changes (n/a, README-only).
- [x] Documentation updated (this is the documentation update).