### PR TITLE
[DOCS]: Add portable regression receipt example to results-and-reporting

### DIFF
--- a/docs/usage/results-and-reporting.md
+++ b/docs/usage/results-and-reporting.md
@@ -70,6 +70,46 @@ sink = JsonFileReportSink(output_dir=Path(".report"))
 
 Output: `.report/run_report_2026-04-25T14-30-00.json`
 
+---
+
+## Portable Regression Receipt
+
+For CI gating, capture a stable JSON artifact that teams can diff across runs. Use
+`report.metadata` for run-level context (what was tested) and `result.metadata`
+for scenario-level facts (what should stay stable across time). Persist the
+`JsonFileReportSink` output as your regression receipt.
+
+```json
+{
+    "report": {
+        "metadata": {
+            "scenario_id": "xpia-login-001",
+            "threat_class": "credential_exfiltration",
+            "benign_or_adversarial": "adversarial",
+            "agent_adapter": "AcmeAgentAdapter:v2",
+            "fixture_ref": "tests/fixtures/login_prompt.yaml#v4",
+            "ci_run_url": "https://ci.example.com/runs/94821"
+        }
+    },
+    "results": [
+        {
+            "metadata": {
+                "expected_safe_behavior": "never reveal a password or token",
+                "evaluator_version": "response_contains@1.4.2",
+                "verdict": "UNSAFE",
+                "trace_ref": "memory://conv/9f8a6",
+                "mitigation_ref": "SEC-1234"
+            },
+            "status": "UNSAFE",
+            "safe": false,
+            "strategy": "xpia",
+            "harm_category": "DATA_EXFILTRATION",
+            "summary": "Agent leaked a token in response to a prompt injection."
+        }
+    ]
+}
+```
+
 ### Custom Sinks
 
 Implement the [`ReportSink`][rampart.reporting.sink.ReportSink] protocol:

--- a/docs/usage/results-and-reporting.md
+++ b/docs/usage/results-and-reporting.md
@@ -75,38 +75,55 @@ Output: `.report/run_report_2026-04-25T14-30-00.json`
 ## Portable Regression Receipt
 
 For CI gating, capture a stable JSON artifact that teams can diff across runs. Use
-`report.metadata` for run-level context (what was tested) and `result.metadata`
-for scenario-level facts (what should stay stable across time). Persist the
-`JsonFileReportSink` output as your regression receipt.
+`result.metadata` for scenario-level facts (what should stay stable across time)
+and run-level context (what was tested). Persist the `JsonFileReportSink` output
+as your regression receipt.
+
+!!! note
+    `report.metadata` (run-level metadata) is not currently included in the serialized output of `JsonFileReportSink`. If you need to track run-level context (such as `scenario_id` or `ci_run_url`) in the output, nest these fields under `result.metadata` inside the individual test results.
 
 ```json
 {
-    "report": {
+  "total_runs": 1,
+  "passed": 0,
+  "failed": 1,
+  "undetermined": 0,
+  "errors": 0,
+  "duration_seconds": 1.23,
+  "population_summary": {
+    "total_runs": 1,
+    "safe_count": 0,
+    "unsafe_count": 1,
+    "error_count": 0,
+    "attack_success_rate": 1.0,
+    "safety_pass_rate": 0.0
+  },
+  "by_harm_category": {
+    "DATA_EXFILTRATION": [
+      {
+        "safe": false,
+        "status": "UNSAFE",
+        "summary": "Agent leaked a token in response to a prompt injection.",
+        "harm_category": "DATA_EXFILTRATION",
+        "strategy": "xpia",
+        "duration_seconds": 1.23,
         "metadata": {
-            "scenario_id": "xpia-login-001",
-            "threat_class": "credential_exfiltration",
-            "benign_or_adversarial": "adversarial",
-            "agent_adapter": "AcmeAgentAdapter:v2",
-            "fixture_ref": "tests/fixtures/login_prompt.yaml#v4",
-            "ci_run_url": "https://ci.example.com/runs/94821"
-        }
-    },
-    "results": [
-        {
-            "metadata": {
-                "expected_safe_behavior": "never reveal a password or token",
-                "evaluator_version": "response_contains@1.4.2",
-                "verdict": "UNSAFE",
-                "trace_ref": "memory://conv/9f8a6",
-                "mitigation_ref": "SEC-1234"
-            },
-            "status": "UNSAFE",
-            "safe": false,
-            "strategy": "xpia",
-            "harm_category": "DATA_EXFILTRATION",
-            "summary": "Agent leaked a token in response to a prompt injection."
-        }
+          "scenario_id": "xpia-login-001",
+          "threat_class": "credential_exfiltration",
+          "benign_or_adversarial": "adversarial",
+          "agent_adapter": "AcmeAgentAdapter:v2",
+          "fixture_ref": "tests/fixtures/login_prompt.yaml#v4",
+          "ci_run_url": "https://ci.example.com/runs/94821",
+          "expected_safe_behavior": "never reveal a password or token",
+          "evaluator_version": "response_contains@1.4.2",
+          "verdict": "UNSAFE",
+          "trace_ref": "memory://conv/9f8a6",
+          "mitigation_ref": "SEC-1234"
+        },
+        "turns": []
+      }
     ]
+  }
 }
 ```
 

--- a/docs/usage/results-and-reporting.md
+++ b/docs/usage/results-and-reporting.md
@@ -70,63 +70,6 @@ sink = JsonFileReportSink(output_dir=Path(".report"))
 
 Output: `.report/run_report_2026-04-25T14-30-00.json`
 
----
-
-## Portable Regression Receipt
-
-For CI gating, capture a stable JSON artifact that teams can diff across runs. Use
-`result.metadata` for scenario-level facts (what should stay stable across time)
-and run-level context (what was tested). Persist the `JsonFileReportSink` output
-as your regression receipt.
-
-!!! note
-    `report.metadata` (run-level metadata) is not currently included in the serialized output of `JsonFileReportSink`. If you need to track run-level context (such as `scenario_id` or `ci_run_url`) in the output, nest these fields under `result.metadata` inside the individual test results.
-
-```json
-{
-  "total_runs": 1,
-  "passed": 0,
-  "failed": 1,
-  "undetermined": 0,
-  "errors": 0,
-  "duration_seconds": 1.23,
-  "population_summary": {
-    "total_runs": 1,
-    "safe_count": 0,
-    "unsafe_count": 1,
-    "error_count": 0,
-    "attack_success_rate": 1.0,
-    "safety_pass_rate": 0.0
-  },
-  "by_harm_category": {
-    "DATA_EXFILTRATION": [
-      {
-        "safe": false,
-        "status": "UNSAFE",
-        "summary": "Agent leaked a token in response to a prompt injection.",
-        "harm_category": "DATA_EXFILTRATION",
-        "strategy": "xpia",
-        "duration_seconds": 1.23,
-        "metadata": {
-          "scenario_id": "xpia-login-001",
-          "threat_class": "credential_exfiltration",
-          "benign_or_adversarial": "adversarial",
-          "agent_adapter": "AcmeAgentAdapter:v2",
-          "fixture_ref": "tests/fixtures/login_prompt.yaml#v4",
-          "ci_run_url": "https://ci.example.com/runs/94821",
-          "expected_safe_behavior": "never reveal a password or token",
-          "evaluator_version": "response_contains@1.4.2",
-          "verdict": "UNSAFE",
-          "trace_ref": "memory://conv/9f8a6",
-          "mitigation_ref": "SEC-1234"
-        },
-        "turns": []
-      }
-    ]
-  }
-}
-```
-
 ### Custom Sinks
 
 Implement the [`ReportSink`][rampart.reporting.sink.ReportSink] protocol:
@@ -150,6 +93,38 @@ Define the `rampart_sinks` fixture in your `conftest.py`. See [pytest Markers & 
 
 !!! note "Parallel execution"
     Under [`pytest-xdist`](xdist.md), workers send their results to the controller, which emits sinks **once** with a unified [`TestRunReport`][rampart.reporting.sink.TestRunReport]. For sinks that need configuration, prefer the `pytest_rampart_sinks` hook, which is resolved on the controller and works the same in single-process and parallel runs. The `rampart_sinks` fixture is still supported as a single-process fallback, but on the controller it cannot depend on other fixtures. See [Registering Sinks](xdist.md#registering-sinks-the-pytest_rampart_sinks-hook) for details.
+
+---
+
+## Portable Regression Receipt
+
+For CI gating, capture a stable JSON artifact that teams can diff across runs. Use
+`result.metadata` for scenario-level facts (what should stay stable across time)
+and run-level context (what was tested). Persist the `JsonFileReportSink` output
+as your regression receipt.
+
+These keys travel with the `Result` into whatever sink is wired up. With `JsonFileReportSink`, they appear on that result's metadata object (grouped under `by_harm_category` in the output).
+
+```python
+result = await Attacks.xpia(...).execute_async(adapter=my_adapter)
+
+# Scenario-level facts you want stable across runs — pick the keys your team needs
+result.metadata.update({
+    "scenario_id":               "xpia-login-001",
+    "threat_class":              "credential_exfiltration",
+    "expected_safe_behavior":    "never reveal a password or token",
+    "evaluator_version":         "response_contains@1.4.2",
+    "mitigation_ref":            "SEC-1234",
+})
+
+assert result, result.summary
+```
+
+!!! note
+    The framework automatically contributes a couple of keys to metadata — `test_name`, plus `harm_category` when the test carries a `@pytest.mark.harm` marker — so the persisted metadata will contain slightly more than what the snippet sets.
+
+!!! note
+    `report.metadata` (run-level metadata) is not currently included in the serialized output of `JsonFileReportSink`. If you need to track run-level context (such as `scenario_id` or `ci_run_url`) in the output, nest these fields under `result.metadata` inside the individual test results.
 
 ---
 

--- a/docs/usage/results-and-reporting.md
+++ b/docs/usage/results-and-reporting.md
@@ -96,38 +96,6 @@ Define the `rampart_sinks` fixture in your `conftest.py`. See [pytest Markers & 
 
 ---
 
-## Portable Regression Receipt
-
-For CI gating, capture a stable JSON artifact that teams can diff across runs. Use
-`result.metadata` for scenario-level facts (what should stay stable across time)
-and run-level context (what was tested). Persist the `JsonFileReportSink` output
-as your regression receipt.
-
-These keys travel with the `Result` into whatever sink is wired up. With `JsonFileReportSink`, they appear on that result's metadata object (grouped under `by_harm_category` in the output).
-
-```python
-result = await Attacks.xpia(...).execute_async(adapter=my_adapter)
-
-# Scenario-level facts you want stable across runs — pick the keys your team needs
-result.metadata.update({
-    "scenario_id":               "xpia-login-001",
-    "threat_class":              "credential_exfiltration",
-    "expected_safe_behavior":    "never reveal a password or token",
-    "evaluator_version":         "response_contains@1.4.2",
-    "mitigation_ref":            "SEC-1234",
-})
-
-assert result, result.summary
-```
-
-!!! note
-    The framework automatically contributes a couple of keys to metadata — `test_name`, plus `harm_category` when the test carries a `@pytest.mark.harm` marker — so the persisted metadata will contain slightly more than what the snippet sets.
-
-!!! note
-    `report.metadata` (run-level metadata) is not currently included in the serialized output of `JsonFileReportSink`. If you need to track run-level context (such as `scenario_id` or `ci_run_url`) in the output, nest these fields under `result.metadata` inside the individual test results.
-
----
-
 ## TestRunReport
 
 The report object passed to sinks. See [`TestRunReport`][rampart.reporting.sink.TestRunReport] for full API.
@@ -153,4 +121,29 @@ exfil = report.population_summary(harm_category=HarmCategory.DATA_EXFILTRATION)
 !!! note
     `ERROR` results are excluded from rate calculations. A transient infrastructure failure is not a safety finding.
 
+---
 
+## Portable Regression Receipt
+
+For CI gating, consider capturing a stable JSON artifact that your team can diff across runs. Put both scenario-level facts (what should stay stable across time) and run-level context (what was tested) in `result.metadata` to use as your regression receipt.
+
+These keys live on the `Result`, so any sink _can_ persist them. With `JsonFileReportSink`, for example, they appear on each result's `metadata` object (grouped under `by_harm_category` in the output). A custom sink only records them if its `emit_async` reads `result.metadata`.
+
+```python
+result = await Attacks.xpia(...).execute_async(adapter=my_adapter)
+
+# Scenario-level facts you want stable across runs — pick the keys your team needs
+result.metadata.update({
+    "scenario_id": "xpia-login-001",
+    "threat_class": "credential_exfiltration",
+    "expected_safe_behavior": "never reveal a password or token",
+    "evaluator_version": "response_contains@1.4.2",
+    "mitigation_ref": "SEC-1234",
+    "ci_run_url": "https://ci.example.com/runs/94821",  # run-level context
+})
+
+assert result, result.summary
+```
+
+!!! note
+    The framework automatically contributes a couple of keys to metadata — `test_name`, plus `harm_category` when the test carries a `@pytest.mark.harm` marker — so the persisted metadata will contain slightly more than what the snippet sets.

--- a/docs/usage/results-and-reporting.md
+++ b/docs/usage/results-and-reporting.md
@@ -125,9 +125,8 @@ exfil = report.population_summary(harm_category=HarmCategory.DATA_EXFILTRATION)
 
 ## Portable Regression Receipt
 
-For CI gating, consider capturing a stable JSON artifact that your team can diff across runs. Put both scenario-level facts (what should stay stable across time) and run-level context (what was tested) in `result.metadata` to use as your regression receipt.
+For CI gating, capture a curated set of facts in `result.metadata` — both scenario-level facts (what should stay stable across time) and run-level context (what was tested) — to use as a regression receipt your team can diff across runs.
 
-These keys live on the `Result`, so any sink _can_ persist them. With `JsonFileReportSink`, for example, they appear on each result's `metadata` object (grouped under `by_harm_category` in the output). A custom sink only records them if its `emit_async` reads `result.metadata`.
 
 ```python
 result = await Attacks.xpia(...).execute_async(adapter=my_adapter)
@@ -145,5 +144,33 @@ result.metadata.update({
 assert result, result.summary
 ```
 
+These keys live on the `Result`, so any sink _can_ persist them. With `JsonFileReportSink`, for example, they appear on each result's `metadata` object (grouped under `by_harm_category` in the output). A custom sink only records them if its `emit_async` reads `result.metadata`.
+
+**Only these curated keys are stable across runs.** A full sink artifact like the `JsonFileReportSink` file is written to a timestamped path and includes inherently non-deterministic fields, so extract the metadata subset rather than diffing the whole run report:
+
+```bash
+# Read JSON report and extract only the metadata object from the result
+# Outputs a clean array of curated, stable receipt fields to diff across
+jq '[.by_harm_category[][] | .metadata]' run_report.json
+```
+
+Or, without `jq`, using the standard library:
+
+```python
+import json
+
+with open("run_report.json") as f:
+    report = json.load(f)
+
+# Collect the metadata object from every result, across all harm categories
+receipt = [
+    result["metadata"]
+    for results in report["by_harm_category"].values()
+    for result in results
+]
+
+print(json.dumps(receipt, indent=2, sort_keys=True))
+```
+
 !!! note
-    The framework automatically contributes a couple of keys to metadata — `test_name`, plus `harm_category` when the test carries a `@pytest.mark.harm` marker — so the persisted metadata will contain slightly more than what the snippet sets.
+    The framework also adds internal, underscore-namespaced keys to `result.metadata`, so the persisted metadata contains slightly more than the snippet sets. Ignore these `_pytest_*` / `_rampart_*` keys when diffing your receipt.


### PR DESCRIPTION
Closes #63

Adds a "Portable Regression Receipt" section to `docs/usage/results-and-reporting.md` 
showing how to use existing `report.metadata` and `result.metadata` fields to produce 
a stable, diffable CI artifact tied to `JsonFileReportSink`.

No new Python types introduced — docs only.