### PR TITLE
[MAINT]: Group Dependabot security minor patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
         update-types:
           - minor
           - patch
+      security-minor-and-patch:
+        applies-to: security-updates
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /
@@ -18,6 +23,12 @@ updates:
       interval: weekly
     commit-message:
       prefix: "[MAINT]"
+    groups:
+      security-minor-and-patch:
+        applies-to: security-updates
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: pre-commit
     directory: /
@@ -25,3 +36,9 @@ updates:
       interval: weekly
     commit-message:
       prefix: "[MAINT]"
+    groups:
+      security-minor-and-patch:
+        applies-to: security-updates
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Description

Adds explicit Dependabot `security-minor-and-patch` groups for configured ecosystems so minor and patch security updates can be grouped separately from normal version updates. Mirrors microsoft/PyRIT#2018.

This follows up on the recent separate Dependabot security PRs #85, #87, #88, #89, and #90. Those PRs were opened one dependency at a time because Dependabot `groups.applies-to` defaults to `version-updates` when omitted. GitHub's Dependabot options reference documents that `applies-to` supports both `version-updates` and `security-updates`.

The existing `uv` `minor-and-patch` group is preserved for normal version updates. This change adds a matching security-only minor/patch group for `uv`, plus security-only minor/patch groups for `github-actions` and `pre-commit`.

Major security updates are intentionally left ungrouped so higher-risk updates remain isolated for review.

References:

- Dependabot `groups` option: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--
- Dependabot `applies-to` behavior: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--
- Dependabot security updates: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates

## Breaking changes

None.

## Checklist

- [X] `pre-commit run --all-files` passes
- [ ] Tests added or updated for changes
- [ ] Documentation updated