### PR TITLE
[STYLE]: Remove pyright references following #86

### DIFF
--- a/rampart/surfaces/onedrive.py
+++ b/rampart/surfaces/onedrive.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 # msgraph-sdk ships without type stubs; suppress the resulting cascade.
-# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false
 
 """OneDrive surface for RAMPART.
 
@@ -21,9 +20,7 @@ from rampart.core.injection import sleep_until_ready
 if TYPE_CHECKING:
     import types
 
-    from msgraph.graph_service_client import (  # pyright: ignore[reportMissingImports]
-        GraphServiceClient,
-    )
+    from msgraph.graph_service_client import GraphServiceClient
 
     from rampart.core.types import Payload
 


### PR DESCRIPTION
## Description

Drop references to `pyright` following #86. Some other refs dropped in #103 too. This PR gets the rest (which are only in `rampart/surfaces/onedrive.py`.


## Breaking changes
None

## Checklist

- [X] `pre-commit run --all-files` passes
- [ ] Tests added or updated for changes <!-- Please describe what tests were added or updated -->
- [ ] Documentation updated
