### PR TITLE
[FIX]: contain deserialized payload artifacts

### DIFF
--- a/rampart/payloads/_store.py
+++ b/rampart/payloads/_store.py
@@ -368,8 +368,9 @@ class PayloadStore:
             ValueError: If the reference is not a relative path under artifacts/.
         """
         msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
-        if not isinstance(artifact, str):
-            raise ValueError(msg)  # noqa: TRY004 - stable deserialization error
+        is_string_reference = isinstance(artifact, str)
+        if not is_string_reference:
+            raise ValueError(msg)
         artifact_path = Path(artifact)
         if artifact_path.is_absolute() or ".." in artifact_path.parts:
             raise ValueError(msg)
@@ -378,7 +379,7 @@ class PayloadStore:
         except ValueError as exc:
             raise ValueError(msg) from exc
 
-        if not artifact_relative.parts:
+        if artifact_relative == Path():
             raise ValueError(msg)
         return artifact_relative
 

--- a/rampart/payloads/_store.py
+++ b/rampart/payloads/_store.py
@@ -29,7 +29,7 @@ import logging
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from rampart.core.types import Payload, PayloadFormat
 
@@ -360,10 +360,9 @@ class PayloadStore:
             ValueError: If the artifact reference is not a contained string path.
         """
         msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
-        try:
-            artifact_path = Path(cast("str", artifact))
-        except TypeError as exc:
-            raise ValueError(msg) from exc
+        if not isinstance(artifact, str):
+            raise ValueError(msg)  # noqa: TRY004 - stable deserialization error
+        artifact_path = Path(artifact)
         if artifact_path.is_absolute() or ".." in artifact_path.parts:
             raise ValueError(msg)
         try:
@@ -406,6 +405,7 @@ class PayloadStore:
 
         Raises:
             FileNotFoundError: If a referenced artifact is missing.
+            ValueError: If a referenced artifact path is invalid.
         """
         fmt = PayloadFormat(data["format"])
 

--- a/rampart/payloads/_store.py
+++ b/rampart/payloads/_store.py
@@ -29,7 +29,7 @@ import logging
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from rampart.core.types import Payload, PayloadFormat
 
@@ -338,7 +338,11 @@ class PayloadStore:
         directory: Path,
         description: str,
     ) -> None:
-        """Raise if a resolved path escapes a required directory."""
+        """Raise if a resolved path escapes a required directory.
+
+        Raises:
+            ValueError: If the resolved path is outside the directory.
+        """
         resolved_path = path.resolve(strict=False)
         resolved_directory = directory.resolve(strict=False)
         if not resolved_path.is_relative_to(resolved_directory):
@@ -346,10 +350,20 @@ class PayloadStore:
             raise ValueError(msg)
 
     @staticmethod
-    def _resolve_artifact_path(*, collection_dir: Path, artifact: str) -> Path:
-        """Resolve a serialized artifact path inside collection artifacts/."""
+    def _resolve_artifact_path(*, collection_dir: Path, artifact: object) -> Path:
+        """Resolve a serialized artifact path inside collection artifacts/.
+
+        Returns:
+            Path: The validated artifact path.
+
+        Raises:
+            ValueError: If the artifact reference is not a contained string path.
+        """
         msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
-        artifact_path = Path(artifact)
+        try:
+            artifact_path = Path(cast("str", artifact))
+        except TypeError as exc:
+            raise ValueError(msg) from exc
         if artifact_path.is_absolute() or ".." in artifact_path.parts:
             raise ValueError(msg)
         try:

--- a/rampart/payloads/_store.py
+++ b/rampart/payloads/_store.py
@@ -145,6 +145,14 @@ class PayloadStore:
                 msg,
             )
 
+        collection_dir = payloads_path.parent
+        artifacts_dir = collection_dir / "artifacts"
+        self._ensure_within_directory(
+            path=artifacts_dir,
+            directory=collection_dir,
+            description="artifacts directory",
+        )
+
         payloads: list[Payload] = []
         with payloads_path.open("r", encoding="utf-8") as f:
             for raw_line in f:
@@ -153,7 +161,7 @@ class PayloadStore:
                     continue
                 payload = self._deserialize(
                     data=json.loads(line),
-                    collection_dir=payloads_path.parent,
+                    artifacts_dir=artifacts_dir,
                 )
                 if format_filter is None or payload.format == format_filter:
                     payloads.append(payload)
@@ -350,14 +358,14 @@ class PayloadStore:
             raise ValueError(msg)
 
     @staticmethod
-    def _resolve_artifact_path(*, collection_dir: Path, artifact: object) -> Path:
-        """Resolve a serialized artifact path inside collection artifacts/.
+    def _validate_artifact_reference(artifact: object) -> Path:
+        """Validate and normalize a serialized artifact reference.
 
         Returns:
-            Path: The validated artifact path.
+            Path: The artifact path relative to the artifacts directory.
 
         Raises:
-            ValueError: If the artifact reference is not a contained string path.
+            ValueError: If the reference is not a relative path under artifacts/.
         """
         msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
         if not isinstance(artifact, str):
@@ -372,14 +380,20 @@ class PayloadStore:
 
         if not artifact_relative.parts:
             raise ValueError(msg)
+        return artifact_relative
 
-        artifacts_dir = collection_dir / "artifacts"
-        PayloadStore._ensure_within_directory(
-            path=artifacts_dir,
-            directory=collection_dir,
-            description="artifacts directory",
-        )
-        resolved = collection_dir / artifact_path
+    @staticmethod
+    def _resolve_artifact_path(*, artifacts_dir: Path, artifact: object) -> Path:
+        """Resolve a serialized artifact path inside the artifacts directory.
+
+        Returns:
+            Path: The validated artifact path.
+
+        Raises:
+            ValueError: If the artifact reference escapes the artifacts directory.
+        """
+        artifact_relative = PayloadStore._validate_artifact_reference(artifact)
+        resolved = artifacts_dir / artifact_relative
         PayloadStore._ensure_within_directory(
             path=resolved,
             directory=artifacts_dir,
@@ -391,14 +405,13 @@ class PayloadStore:
     def _deserialize(
         *,
         data: dict[str, Any],
-        collection_dir: Path,
+        artifacts_dir: Path,
     ) -> Payload:
         """Deserialize a JSON record back to a Payload.
 
         Args:
             data (dict[str, Any]): JSON record from JSONL.
-            collection_dir (Path): Collection directory for resolving
-                artifact paths.
+            artifacts_dir (Path): Directory for resolving artifact paths.
 
         Returns:
             Payload: Reconstituted Payload.
@@ -412,7 +425,7 @@ class PayloadStore:
         artifact: Path | None = None
         if "artifact" in data:
             artifact_path = PayloadStore._resolve_artifact_path(
-                collection_dir=collection_dir,
+                artifacts_dir=artifacts_dir,
                 artifact=data["artifact"],
             )
             if not artifact_path.exists():

--- a/rampart/payloads/_store.py
+++ b/rampart/payloads/_store.py
@@ -348,18 +348,16 @@ class PayloadStore:
     @staticmethod
     def _resolve_artifact_path(*, collection_dir: Path, artifact: str) -> Path:
         """Resolve a serialized artifact path inside collection artifacts/."""
+        msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
         artifact_path = Path(artifact)
         if artifact_path.is_absolute() or ".." in artifact_path.parts:
-            msg = f"Invalid artifact path: {artifact!r}. Must stay under artifacts/."
             raise ValueError(msg)
         try:
             artifact_relative = artifact_path.relative_to("artifacts")
         except ValueError:
-            msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
-            raise ValueError(msg) from None
+            raise ValueError(msg)  # noqa: B904 - preserve the exception chain
 
         if not artifact_relative.parts:
-            msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
             raise ValueError(msg)
 
         resolved = collection_dir / artifact_path

--- a/rampart/payloads/_store.py
+++ b/rampart/payloads/_store.py
@@ -34,7 +34,6 @@ from typing import Any
 from rampart.core.types import Payload, PayloadFormat
 
 logger = logging.getLogger(__name__)
-_MIN_ARTIFACT_PATH_PARTS = 2
 
 
 class PayloadStore:
@@ -353,10 +352,13 @@ class PayloadStore:
         if artifact_path.is_absolute() or ".." in artifact_path.parts:
             msg = f"Invalid artifact path: {artifact!r}. Must stay under artifacts/."
             raise ValueError(msg)
-        if (
-            len(artifact_path.parts) < _MIN_ARTIFACT_PATH_PARTS
-            or artifact_path.parts[0] != "artifacts"
-        ):
+        try:
+            artifact_relative = artifact_path.relative_to("artifacts")
+        except ValueError:
+            msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
+            raise ValueError(msg) from None
+
+        if not artifact_relative.parts:
             msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
             raise ValueError(msg)
 

--- a/rampart/payloads/_store.py
+++ b/rampart/payloads/_store.py
@@ -34,6 +34,7 @@ from typing import Any
 from rampart.core.types import Payload, PayloadFormat
 
 logger = logging.getLogger(__name__)
+_MIN_ARTIFACT_PATH_PARTS = 2
 
 
 class PayloadStore:
@@ -332,6 +333,42 @@ class PayloadStore:
         return f"artifacts/{filename}"
 
     @staticmethod
+    def _ensure_within_directory(
+        *,
+        path: Path,
+        directory: Path,
+        description: str,
+    ) -> None:
+        """Raise if a resolved path escapes a required directory."""
+        resolved_path = path.resolve(strict=False)
+        resolved_directory = directory.resolve(strict=False)
+        if not resolved_path.is_relative_to(resolved_directory):
+            msg = f"Invalid {description}: {path!s} escapes {directory!s}"
+            raise ValueError(msg)
+
+    @staticmethod
+    def _resolve_artifact_path(*, collection_dir: Path, artifact: str) -> Path:
+        """Resolve a serialized artifact path inside collection artifacts/."""
+        artifact_path = Path(artifact)
+        if artifact_path.is_absolute() or ".." in artifact_path.parts:
+            msg = f"Invalid artifact path: {artifact!r}. Must stay under artifacts/."
+            raise ValueError(msg)
+        if (
+            len(artifact_path.parts) < _MIN_ARTIFACT_PATH_PARTS
+            or artifact_path.parts[0] != "artifacts"
+        ):
+            msg = f"Invalid artifact path: {artifact!r}. Must be under artifacts/."
+            raise ValueError(msg)
+
+        resolved = collection_dir / artifact_path
+        PayloadStore._ensure_within_directory(
+            path=resolved,
+            directory=collection_dir / "artifacts",
+            description="artifact path",
+        )
+        return resolved
+
+    @staticmethod
     def _deserialize(
         *,
         data: dict[str, Any],
@@ -354,7 +391,10 @@ class PayloadStore:
 
         artifact: Path | None = None
         if "artifact" in data:
-            artifact_path = collection_dir / data["artifact"]
+            artifact_path = PayloadStore._resolve_artifact_path(
+                collection_dir=collection_dir,
+                artifact=data["artifact"],
+            )
             if not artifact_path.exists():
                 msg = f"Missing artifact: {artifact_path}"
                 raise FileNotFoundError(msg)

--- a/rampart/payloads/_store.py
+++ b/rampart/payloads/_store.py
@@ -354,16 +354,22 @@ class PayloadStore:
             raise ValueError(msg)
         try:
             artifact_relative = artifact_path.relative_to("artifacts")
-        except ValueError:
-            raise ValueError(msg)  # noqa: B904 - preserve the exception chain
+        except ValueError as exc:
+            raise ValueError(msg) from exc
 
         if not artifact_relative.parts:
             raise ValueError(msg)
 
+        artifacts_dir = collection_dir / "artifacts"
+        PayloadStore._ensure_within_directory(
+            path=artifacts_dir,
+            directory=collection_dir,
+            description="artifacts directory",
+        )
         resolved = collection_dir / artifact_path
         PayloadStore._ensure_within_directory(
             path=resolved,
-            directory=collection_dir / "artifacts",
+            directory=artifacts_dir,
             description="artifact path",
         )
         return resolved

--- a/tests/unit/payloads/test_payload_store_security.py
+++ b/tests/unit/payloads/test_payload_store_security.py
@@ -11,7 +11,7 @@ import pytest
 from rampart.payloads._store import PayloadStore
 
 
-def _write_collection_record(collection_dir: Path, artifact: str) -> None:
+def _write_collection_record(collection_dir: Path, artifact: object) -> None:
     collection_dir.mkdir(parents=True, exist_ok=True)
     record: dict[str, object] = {
         "id": "safe-id",
@@ -38,6 +38,23 @@ def test_payload_store_rejects_deserialized_artifact_escape(
     artifact: str,
 ) -> None:
     """Serialized artifact paths must stay under the collection artifacts dir."""
+    collection_dir = tmp_path / "store" / "collection"
+    _write_collection_record(collection_dir, artifact)
+
+    store = PayloadStore(root=tmp_path / "store")
+    with pytest.raises(ValueError, match="Invalid artifact path"):
+        store.load("collection")
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [None, 7, ["artifacts/file.pdf"], {"path": "artifacts/file.pdf"}],
+)
+def test_payload_store_rejects_non_string_deserialized_artifact(
+    tmp_path: Path,
+    artifact: object,
+) -> None:
+    """Serialized artifact references must be strings."""
     collection_dir = tmp_path / "store" / "collection"
     _write_collection_record(collection_dir, artifact)
 

--- a/tests/unit/payloads/test_payload_store_security.py
+++ b/tests/unit/payloads/test_payload_store_security.py
@@ -68,6 +68,30 @@ def test_payload_store_rejects_deserialized_artifact_symlink_escape(
         store.load("collection")
 
 
+def test_payload_store_rejects_deserialized_artifacts_directory_symlink_escape(
+    tmp_path: Path,
+) -> None:
+    """The collection artifacts directory cannot resolve outside the collection."""
+    collection_dir = tmp_path / "store" / "collection"
+    collection_dir.mkdir(parents=True)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "linked.pdf").write_bytes(b"outside")
+    try:
+        (collection_dir / "artifacts").symlink_to(
+            outside_dir,
+            target_is_directory=True,
+        )
+    except OSError as exc:
+        pytest.skip(f"symlinks are not available on this platform: {exc}")
+
+    _write_collection_record(collection_dir, "artifacts/linked.pdf")
+
+    store = PayloadStore(root=tmp_path / "store")
+    with pytest.raises(ValueError, match=r"artifacts directory.*escapes"):
+        store.load("collection")
+
+
 def test_payload_store_rejects_missing_deserialized_artifact(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/payloads/test_payload_store_security.py
+++ b/tests/unit/payloads/test_payload_store_security.py
@@ -23,99 +23,101 @@ def _write_collection_record(collection_dir: Path, artifact: object) -> None:
     (collection_dir / "payloads.jsonl").write_text(json.dumps(record) + "\n")
 
 
-@pytest.mark.parametrize(
-    "artifact",
-    [
-        "../outside.pdf",
-        "artifacts/../outside.pdf",
-        "/tmp/outside.pdf",
-        "outside.pdf",
-        "artifacts",
-    ],
-)
-def test_payload_store_rejects_deserialized_artifact_escape(
-    tmp_path: Path,
-    artifact: str,
-) -> None:
-    """Serialized artifact paths must stay under the collection artifacts dir."""
-    collection_dir = tmp_path / "store" / "collection"
-    _write_collection_record(collection_dir, artifact)
+class TestPayloadStoreArtifactContainment:
+    @pytest.mark.parametrize(
+        "artifact",
+        [
+            "../outside.pdf",
+            "artifacts/../outside.pdf",
+            "/tmp/outside.pdf",
+            "outside.pdf",
+            "artifacts",
+        ],
+    )
+    def test_payload_store_rejects_deserialized_artifact_escape(
+        self,
+        tmp_path: Path,
+        artifact: str,
+    ) -> None:
+        """Serialized artifact paths must stay under the collection artifacts dir."""
+        collection_dir = tmp_path / "store" / "collection"
+        _write_collection_record(collection_dir, artifact)
 
-    store = PayloadStore(root=tmp_path / "store")
-    with pytest.raises(ValueError, match="Invalid artifact path"):
-        store.load("collection")
+        store = PayloadStore(root=tmp_path / "store")
+        with pytest.raises(ValueError, match="Invalid artifact path"):
+            store.load("collection")
 
+    @pytest.mark.parametrize(
+        "artifact",
+        [None, 7, ["artifacts/file.pdf"], {"path": "artifacts/file.pdf"}],
+    )
+    def test_payload_store_rejects_non_string_deserialized_artifact(
+        self,
+        tmp_path: Path,
+        artifact: object,
+    ) -> None:
+        """Serialized artifact references must be strings."""
+        collection_dir = tmp_path / "store" / "collection"
+        _write_collection_record(collection_dir, artifact)
 
-@pytest.mark.parametrize(
-    "artifact",
-    [None, 7, ["artifacts/file.pdf"], {"path": "artifacts/file.pdf"}],
-)
-def test_payload_store_rejects_non_string_deserialized_artifact(
-    tmp_path: Path,
-    artifact: object,
-) -> None:
-    """Serialized artifact references must be strings."""
-    collection_dir = tmp_path / "store" / "collection"
-    _write_collection_record(collection_dir, artifact)
+        store = PayloadStore(root=tmp_path / "store")
+        with pytest.raises(ValueError, match="Invalid artifact path"):
+            store.load("collection")
 
-    store = PayloadStore(root=tmp_path / "store")
-    with pytest.raises(ValueError, match="Invalid artifact path"):
-        store.load("collection")
+    def test_payload_store_rejects_deserialized_artifact_symlink_escape(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Reject artifact paths resolving through symlinks outside artifacts."""
+        collection_dir = tmp_path / "store" / "collection"
+        artifacts_dir = collection_dir / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        outside = tmp_path / "outside.pdf"
+        outside.write_bytes(b"outside")
+        symlink = artifacts_dir / "linked.pdf"
+        try:
+            symlink.symlink_to(outside)
+        except OSError as exc:
+            pytest.skip(f"symlinks are not available on this platform: {exc}")
 
+        _write_collection_record(collection_dir, "artifacts/linked.pdf")
 
-def test_payload_store_rejects_deserialized_artifact_symlink_escape(
-    tmp_path: Path,
-) -> None:
-    """Serialized artifact paths cannot resolve through symlinks outside artifacts."""
-    collection_dir = tmp_path / "store" / "collection"
-    artifacts_dir = collection_dir / "artifacts"
-    artifacts_dir.mkdir(parents=True)
-    outside = tmp_path / "outside.pdf"
-    outside.write_bytes(b"outside")
-    symlink = artifacts_dir / "linked.pdf"
-    try:
-        symlink.symlink_to(outside)
-    except OSError as exc:
-        pytest.skip(f"symlinks are not available on this platform: {exc}")
+        store = PayloadStore(root=tmp_path / "store")
+        with pytest.raises(ValueError, match="escapes"):
+            store.load("collection")
 
-    _write_collection_record(collection_dir, "artifacts/linked.pdf")
+    def test_payload_store_rejects_deserialized_artifacts_directory_symlink_escape(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The collection artifacts directory cannot resolve outside the collection."""
+        collection_dir = tmp_path / "store" / "collection"
+        collection_dir.mkdir(parents=True)
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        (outside_dir / "linked.pdf").write_bytes(b"outside")
+        try:
+            (collection_dir / "artifacts").symlink_to(
+                outside_dir,
+                target_is_directory=True,
+            )
+        except OSError as exc:
+            pytest.skip(f"symlinks are not available on this platform: {exc}")
 
-    store = PayloadStore(root=tmp_path / "store")
-    with pytest.raises(ValueError, match="escapes"):
-        store.load("collection")
+        _write_collection_record(collection_dir, "artifacts/linked.pdf")
 
+        store = PayloadStore(root=tmp_path / "store")
+        with pytest.raises(ValueError, match=r"artifacts directory.*escapes"):
+            store.load("collection")
 
-def test_payload_store_rejects_deserialized_artifacts_directory_symlink_escape(
-    tmp_path: Path,
-) -> None:
-    """The collection artifacts directory cannot resolve outside the collection."""
-    collection_dir = tmp_path / "store" / "collection"
-    collection_dir.mkdir(parents=True)
-    outside_dir = tmp_path / "outside"
-    outside_dir.mkdir()
-    (outside_dir / "linked.pdf").write_bytes(b"outside")
-    try:
-        (collection_dir / "artifacts").symlink_to(
-            outside_dir,
-            target_is_directory=True,
-        )
-    except OSError as exc:
-        pytest.skip(f"symlinks are not available on this platform: {exc}")
+    def test_payload_store_rejects_missing_deserialized_artifact(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A valid serialized artifact path must refer to an existing file."""
+        collection_dir = tmp_path / "store" / "collection"
+        _write_collection_record(collection_dir, "artifacts/gone.pdf")
 
-    _write_collection_record(collection_dir, "artifacts/linked.pdf")
-
-    store = PayloadStore(root=tmp_path / "store")
-    with pytest.raises(ValueError, match=r"artifacts directory.*escapes"):
-        store.load("collection")
-
-
-def test_payload_store_rejects_missing_deserialized_artifact(
-    tmp_path: Path,
-) -> None:
-    """A valid serialized artifact path must refer to an existing file."""
-    collection_dir = tmp_path / "store" / "collection"
-    _write_collection_record(collection_dir, "artifacts/gone.pdf")
-
-    store = PayloadStore(root=tmp_path / "store")
-    with pytest.raises(FileNotFoundError, match="Missing artifact"):
-        store.load("collection")
+        store = PayloadStore(root=tmp_path / "store")
+        with pytest.raises(FileNotFoundError, match="Missing artifact"):
+            store.load("collection")

--- a/tests/unit/payloads/test_payload_store_security.py
+++ b/tests/unit/payloads/test_payload_store_security.py
@@ -20,7 +20,10 @@ def _write_collection_record(collection_dir: Path, artifact: object) -> None:
         "metadata": {},
         "artifact": artifact,
     }
-    (collection_dir / "payloads.jsonl").write_text(json.dumps(record) + "\n")
+    (collection_dir / "payloads.jsonl").write_text(
+        json.dumps(record) + "\n",
+        encoding="utf-8",
+    )
 
 
 class TestPayloadStoreArtifactContainment:

--- a/tests/unit/payloads/test_payload_store_security.py
+++ b/tests/unit/payloads/test_payload_store_security.py
@@ -30,6 +30,7 @@ def _write_collection_record(collection_dir: Path, artifact: str) -> None:
         "artifacts/../outside.pdf",
         "/tmp/outside.pdf",
         "outside.pdf",
+        "artifacts",
     ],
 )
 def test_payload_store_rejects_deserialized_artifact_escape(
@@ -64,4 +65,16 @@ def test_payload_store_rejects_deserialized_artifact_symlink_escape(
 
     store = PayloadStore(root=tmp_path / "store")
     with pytest.raises(ValueError, match="escapes"):
+        store.load("collection")
+
+
+def test_payload_store_rejects_missing_deserialized_artifact(
+    tmp_path: Path,
+) -> None:
+    """A valid serialized artifact path must refer to an existing file."""
+    collection_dir = tmp_path / "store" / "collection"
+    _write_collection_record(collection_dir, "artifacts/gone.pdf")
+
+    store = PayloadStore(root=tmp_path / "store")
+    with pytest.raises(FileNotFoundError, match="Missing artifact"):
         store.load("collection")

--- a/tests/unit/payloads/test_payload_store_security.py
+++ b/tests/unit/payloads/test_payload_store_security.py
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Security tests for payload artifact path handling."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rampart.payloads._store import PayloadStore
+
+
+def _write_collection_record(collection_dir: Path, artifact: str) -> None:
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    record: dict[str, object] = {
+        "id": "safe-id",
+        "content": "binary",
+        "format": "pdf",
+        "metadata": {},
+        "artifact": artifact,
+    }
+    (collection_dir / "payloads.jsonl").write_text(json.dumps(record) + "\n")
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [
+        "../outside.pdf",
+        "artifacts/../outside.pdf",
+        "/tmp/outside.pdf",
+        "outside.pdf",
+    ],
+)
+def test_payload_store_rejects_deserialized_artifact_escape(
+    tmp_path: Path,
+    artifact: str,
+) -> None:
+    """Serialized artifact paths must stay under the collection artifacts dir."""
+    collection_dir = tmp_path / "store" / "collection"
+    _write_collection_record(collection_dir, artifact)
+
+    store = PayloadStore(root=tmp_path / "store")
+    with pytest.raises(ValueError, match="Invalid artifact path"):
+        store.load("collection")
+
+
+def test_payload_store_rejects_deserialized_artifact_symlink_escape(
+    tmp_path: Path,
+) -> None:
+    """Serialized artifact paths cannot resolve through symlinks outside artifacts."""
+    collection_dir = tmp_path / "store" / "collection"
+    artifacts_dir = collection_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.pdf"
+    outside.write_bytes(b"outside")
+    symlink = artifacts_dir / "linked.pdf"
+    try:
+        symlink.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks are not available on this platform: {exc}")
+
+    _write_collection_record(collection_dir, "artifacts/linked.pdf")
+
+    store = PayloadStore(root=tmp_path / "store")
+    with pytest.raises(ValueError, match="escapes"):
+        store.load("collection")


### PR DESCRIPTION
## Summary

This is the focused follow-up requested in https://github.com/microsoft/RAMPART/pull/57#issuecomment-4907125743.

It keeps the load-time artifact containment hardening only: when deserializing a persisted payload collection, artifact references now have to remain under the collection's `artifacts/` directory after normalization and symlink resolution.

## What changed

- Adds `_resolve_artifact_path()` in `rampart/payloads/_store.py` for deserialized artifact references.
- Rejects persisted artifact paths that are absolute, contain `..`, or do not start with `artifacts/`.
- Resolves the final path and rejects symlink escapes outside the collection's `artifacts/` directory.
- Adds regression tests for traversal, absolute/non-artifacts paths, and symlink escape handling.

## Scope notes

- This does **not** add `Payload.id` validation.
- This does **not** add `rampart/core/payload_ids.py`.
- This does **not** change `_copy_file_artifact()` or `OneDriveSurface.upload_async()`.
- This is framed as defense-in-depth for untrusted/shared collection deserialization, not as a high-severity payload-ID vulnerability.

## Test plan

Host-local:

```bash
uv run pytest tests/unit/payloads/test_payload_store_security.py -q
uv run pytest tests/unit/payloads/test_store.py tests/unit/payloads/test_payload_store_security.py -q
uv run ruff check rampart/payloads/_store.py tests/unit/payloads/test_payload_store_security.py
uv run ruff format --check rampart/payloads/_store.py tests/unit/payloads/test_payload_store_security.py
uv run ty check rampart/payloads/_store.py tests/unit/payloads/test_payload_store_security.py
uv run pytest -q
python -m compileall -q rampart tests
git diff --check
```

Results:

- Focused new tests: `5 passed`
- Existing payload store + new tests: `18 passed`
- Full suite: `617 passed, 5 skipped`
- Ruff check/format: passed
- Ty check: passed
- Compileall/diff whitespace check: passed

Container validation:

```bash
docker run --rm -e CI=true -v "$PWD":/work -w /work python:3.12-slim bash -lc 'apt-get update -qq && apt-get install -y -qq git cargo >/dev/null && python -m pip install --quiet uv && uv run pytest tests/unit/payloads/test_store.py tests/unit/payloads/test_payload_store_security.py -q && uv run ruff check rampart/payloads/_store.py tests/unit/payloads/test_payload_store_security.py && uv run ty check rampart/payloads/_store.py tests/unit/payloads/test_payload_store_security.py && git diff --check'
```

Result: passed (`18 passed`; ruff, ty, and diff whitespace checks passed).
