### PR TITLE
[MAINT]: Group github-actions minor/patch Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
     commit-message:
       prefix: "[MAINT]"
     groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
       security-minor-and-patch:
         applies-to: security-updates
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,10 @@ updates:
     commit-message:
       prefix: "[MAINT]"
     groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
       security-minor-and-patch:
         applies-to: security-updates
         update-types:


### PR DESCRIPTION
## What

Adds a `minor-and-patch` group to the `github-actions` ecosystem in `.github/dependabot.yml`, mirroring the existing `uv` ecosystem configuration.

```yaml
  - package-ecosystem: github-actions
    directory: /
    schedule:
      interval: weekly
    commit-message:
      prefix: "[MAINT]"
    groups:
      minor-and-patch:
        update-types:
          - minor
          - patch
```

## Why

Without a version-update group, Dependabot opens **one PR per dependency** for the `github-actions` ecosystem. Because `github/codeql-action/init` and `github/codeql-action/analyze` are distinct dependency names, a single action upgrade gets split into two PRs (e.g. #107 and #109 for `4.36.2 → 4.37.0`).

CodeQL requires the `init` and `analyze` steps to run the **same version**, so each split PR on its own leaves `codeql.yml` with mismatched versions and fails CI with a configuration error:

> `Loaded a configuration file for version '4.36.2', but running version '4.37.0'`

Grouping combines both bumps into a single PR/commit, so the workflow is never left in a mismatched state.

## Effect

- Applies to **future** Actions version updates once merged to `main` (Dependabot reads its config from the default branch).
- After merge, the existing split PRs can be superseded by a single grouped PR via the next Dependabot run — either the weekly schedule, **Insights → Dependency graph → Dependabot → "Check for updates"**, or commenting `@dependabot recreate` on #107/#109.

## Notes

- Config-only change; no code or workflow behavior is affected.
- Scoped to `minor` and `patch` updates, consistent with the `uv` ecosystem group already in this file.