### PR TITLE
[FIX]: Fix async context manager protocol typing

### DIFF
--- a/rampart/core/adapter.py
+++ b/rampart/core/adapter.py
@@ -10,22 +10,20 @@ their agent to the RAMPART framework.
 from __future__ import annotations
 
 from contextlib import AbstractAsyncContextManager
-from typing import TYPE_CHECKING, Protocol, Self, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    import types
-
     from rampart.core.manifest import AppManifest
     from rampart.core.types import ObservabilityLevel, Request, Response
 
 
 @runtime_checkable
-class Session(AbstractAsyncContextManager["Session"], Protocol):
+class Session(AbstractAsyncContextManager["Session", None], Protocol):
     """A bounded unit of interaction with the agent.
 
     Sessions are async context managers. Entering returns the session
-    ready for use; exiting guarantees cleanup of any resources the
-    adapter holds (API clients, browser contexts, temporary state).
+    ready for use; exiting guarantees idempotent cleanup of any resources
+    the adapter holds (API clients, browser contexts, temporary state).
 
     Fresh state = fresh session. Create a new one via the adapter.
     """
@@ -44,20 +42,6 @@ class Session(AbstractAsyncContextManager["Session"], Protocol):
         Returns:
             Response: The agent's response with all observable data.
         """
-        ...
-
-    async def __aenter__(self) -> Self:
-        """Enter the session context. Returns self."""
-        ...
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: types.TracebackType | None,
-        /,
-    ) -> None:
-        """Clean up session resources. Must be idempotent."""
         ...
 
 

--- a/rampart/core/injection.py
+++ b/rampart/core/injection.py
@@ -14,11 +14,9 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import AbstractAsyncContextManager
-from typing import TYPE_CHECKING, Protocol, Self, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    import types
-
     from rampart.core.types import Payload
 
 
@@ -27,8 +25,9 @@ class InjectionHandle(AbstractAsyncContextManager["InjectionHandle", None], Prot
     """A prepared injection, ready to activate as an async context manager.
 
     Returned by Surface.inject(). Entering activates the injection
-    (writes the payload to the data source); exiting removes it
-    (guaranteed cleanup even on exceptions).
+    (writes the payload to the data source); exiting removes it.
+    Cleanup is guaranteed even on exceptions, must be idempotent, and
+    must not raise.
 
     Execution strategies depend only on this protocol — never on
     Surface or its concrete implementations.
@@ -50,20 +49,6 @@ class InjectionHandle(AbstractAsyncContextManager["InjectionHandle", None], Prot
         Implementations should raise `TimeoutError` if readiness
         operations are long-running to prevent indefinite blocking.
         """
-        ...
-
-    async def __aenter__(self) -> Self:
-        """Activate the injection (write payload to data source)."""
-        ...
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: types.TracebackType | None,
-        /,
-    ) -> None:
-        """Remove the injection. Must be idempotent. Must not raise."""
         ...
 
 


### PR DESCRIPTION
## Description

`ty` (>=0.59.0, as seen in #118) rejects `Session` and `InjectionHandle` when they are passed to `AsyncExitStack.enter_async_context`.

Both protocols inherit their context manager methods from `AbstractAsyncContextManager`, but also redeclare `__aenter__` using `Self`. That leaves `ty` trying to reconcile two recursive versions of the same signature.

This removes the duplicate `__aenter__` and `__aexit__` declarations and relies on the inherited signatures instead. `Session` now specifies `None` as its exit return type, preserving the previous cleanup contract.

The XPIA call sites do not need to change.

Validation:

- `uv run ty check`
- `uv run pytest tests/unit/core/test_adapter.py tests/unit/core/test_injection.py tests/unit/attacks/test_xpia.py`
- `uv run pre-commit run --all-files`

## Breaking changes

None.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Tests added or updated for changes (existing protocol and XPIA tests cover the affected behavior)
- [x] Documentation updated