### PR TITLE
[FEAT]: Add structured prompt template validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "jinja2>=3.1.6",
+    "pydantic>=2.13.4",
     "pyrit==0.13.0",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",

--- a/rampart/common/templates.py
+++ b/rampart/common/templates.py
@@ -91,7 +91,7 @@ class TemplateParameterError(ValueError):
         super().__init__(msg)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class PromptTemplate:
     """Compiled prompt template with metadata and an explicit render contract."""
 

--- a/rampart/common/templates.py
+++ b/rampart/common/templates.py
@@ -19,57 +19,30 @@ render call before evaluating Jinja markup.
 
 from __future__ import annotations
 
+from collections.abc import Hashable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, TypeAlias, TypeVar
 
 import yaml
 from jinja2 import Environment, StrictUndefined, Template, meta, select_autoescape
-from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+from pydantic import AfterValidator, BaseModel, ConfigDict, ValidationError
+
+__all__ = [
+    "PromptTemplate",
+    "PromptTemplateSchemaError",
+    "TemplateParameterError",
+]
 
 if TYPE_CHECKING:
     from collections.abc import Collection
     from pathlib import Path
+    from typing import Self
 
 
 _JINJA_ENVIRONMENT = Environment(
     autoescape=select_autoescape(default_for_string=False, default=False),
     undefined=StrictUndefined,
 )
-
-
-class _PromptTemplateYaml(BaseModel):
-    """Strict schema for the serialized YAML representation."""
-
-    model_config = ConfigDict(
-        extra="forbid",
-        frozen=True,
-        hide_input_in_errors=True,
-        strict=True,
-    )
-
-    name: str
-    parameters: list[str]
-    value: str
-    description: str | None = None
-
-    @field_validator("parameters")
-    @classmethod
-    def _require_unique_parameters(cls, parameters: list[str]) -> list[str]:
-        """Reject duplicate parameter declarations.
-
-        Args:
-            parameters: Parameter keys parsed from YAML.
-
-        Returns:
-            list[str]: The validated parameter keys.
-
-        Raises:
-            ValueError: If a parameter key appears more than once.
-        """
-        if len(parameters) != len(set(parameters)):
-            msg = "parameters must contain unique keys"
-            raise ValueError(msg)
-        return parameters
 
 
 class PromptTemplateSchemaError(ValueError):
@@ -127,6 +100,36 @@ class PromptTemplate:
     parameter_keys: tuple[str, ...]
     _template: Template = field(repr=False, compare=False)
 
+    @classmethod
+    def from_yaml(cls, path: Path) -> Self:
+        """Load and compile a prompt template from YAML.
+
+        ``name``, ``parameters``, and ``value`` are required. ``description``
+        is optional. Declared parameters must exactly match the variables
+        referenced by the Jinja template.
+
+        Args:
+            path: Path to the YAML template file.
+
+        Returns:
+            Self: A structured, compiled prompt template.
+
+        Raises:
+            FileNotFoundError: If *path* does not exist.
+            PromptTemplateSchemaError: If the YAML data does not match the
+                schema, including duplicate parameter declarations.
+            ValueError: If parameter declarations do not match the Jinja
+                template variables.
+            yaml.YAMLError: If the file is not valid YAML.
+        """
+        definition = _load_yaml_definition(path)
+        return cls(
+            name=definition.name,
+            description=definition.description,
+            parameter_keys=tuple(definition.parameters),
+            _template=_compile_template(definition, path=path),
+        )
+
     def render(self, **kwargs: object) -> str:
         """Render with exactly the declared keyword arguments.
 
@@ -153,57 +156,104 @@ class PromptTemplate:
         return self._template.render(**kwargs)
 
 
-def load_prompt_template(path: Path) -> PromptTemplate:
-    """Load and compile a structured YAML prompt template.
+_UniqueItemT = TypeVar("_UniqueItemT", bound=Hashable)
 
-    ``name``, ``parameters``, and ``value`` are required. ``description``
-    is optional. The declared parameters must exactly match the variables
-    referenced by the Jinja template.
+
+def _require_unique(values: list[_UniqueItemT]) -> list[_UniqueItemT]:
+    """Reject duplicate values.
 
     Args:
-        path: Absolute path to the YAML template file
-            (e.g. ``.../prompts/llm_judge.yaml``).
+        values: Values to validate.
 
     Returns:
-        PromptTemplate: Structured metadata and a compiled template.
+        list[_UniqueItemT]: The validated values in their original order.
+
+    Raises:
+        ValueError: If any value appears more than once.
+    """
+    if len(values) != len(set(values)):
+        msg = "items must be unique"
+        raise ValueError(msg)
+    return values
+
+
+_UniqueList: TypeAlias = Annotated[
+    list[_UniqueItemT],
+    AfterValidator(_require_unique),
+]
+
+
+class _PromptTemplateYaml(BaseModel):
+    """Strict schema for the serialized YAML representation."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        hide_input_in_errors=True,
+        strict=True,
+    )
+
+    name: str
+    parameters: _UniqueList[str]
+    value: str
+    description: str | None = None
+
+
+def _load_yaml_definition(path: Path) -> _PromptTemplateYaml:
+    """Load and validate the serialized YAML representation.
+
+    Args:
+        path: Path to the YAML template file.
+
+    Returns:
+        _PromptTemplateYaml: The validated YAML definition.
 
     Raises:
         FileNotFoundError: If *path* does not exist.
         PromptTemplateSchemaError: If the YAML data does not match the schema,
             including duplicate parameter declarations.
-        ValueError: If parameter declarations do not match the Jinja template
-            variables.
         yaml.YAMLError: If the file is not valid YAML.
     """
     with path.open(encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
     try:
-        definition = _PromptTemplateYaml.model_validate(data)
+        return _PromptTemplateYaml.model_validate(data)
     except ValidationError as exc:
         raise PromptTemplateSchemaError(path=path, details=str(exc)) from exc
 
-    parameter_keys = tuple(definition.parameters)
+
+def _compile_template(
+    definition: _PromptTemplateYaml,
+    *,
+    path: Path,
+) -> Template:
+    """Compile a validated definition after checking its parameter contract.
+
+    Args:
+        definition: Validated YAML template definition.
+        path: Source path used in Jinja diagnostics.
+
+    Returns:
+        Template: The compiled Jinja template.
+
+    Raises:
+        ValueError: If declared parameters do not match the Jinja variables.
+    """
     parsed = _JINJA_ENVIRONMENT.parse(
         definition.value,
         name=definition.name,
         filename=str(path),
     )
     referenced_keys = meta.find_undeclared_variables(parsed)
-    declared_keys = set(parameter_keys)
+    declared_keys = set(definition.parameters)
     if referenced_keys != declared_keys:
         missing = tuple(sorted(referenced_keys - declared_keys))
         unused = tuple(sorted(declared_keys - referenced_keys))
         msg = (
-            f"Prompt template {definition.name!r} parameter declarations do not match "
-            "its "
+            f"Prompt template {definition.name!r} parameters do not match its "
             f"Jinja variables: missing={missing!r}, unused={unused!r}"
         )
         raise ValueError(msg)
 
-    return PromptTemplate(
-        name=definition.name,
-        description=definition.description,
-        parameter_keys=parameter_keys,
-        _template=_JINJA_ENVIRONMENT.from_string(parsed),
-    )
+    return _JINJA_ENVIRONMENT.from_string(parsed)

--- a/rampart/common/templates.py
+++ b/rampart/common/templates.py
@@ -11,6 +11,7 @@ directories. Each file uses this schema:
 - ``value`` (required): Jinja2 template source.
 - ``description`` (optional): Human-readable purpose; defaults to ``None``.
 
+Unknown keys and type coercion are rejected. Parameter names must be unique.
 The loader maps ``parameters`` to :attr:`PromptTemplate.parameter_keys`,
 compiles ``value``, and returns a structured template that validates every
 render call before evaluating Jinja markup.
@@ -18,14 +19,15 @@ render call before evaluating Jinja markup.
 
 from __future__ import annotations
 
-from collections.abc import Collection, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import yaml
 from jinja2 import Environment, StrictUndefined, Template, meta, select_autoescape
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
     from pathlib import Path
 
 
@@ -33,6 +35,56 @@ _JINJA_ENVIRONMENT = Environment(
     autoescape=select_autoescape(default_for_string=False, default=False),
     undefined=StrictUndefined,
 )
+
+
+class _PromptTemplateYaml(BaseModel):
+    """Strict schema for the serialized YAML representation."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        hide_input_in_errors=True,
+        strict=True,
+    )
+
+    name: str
+    parameters: list[str]
+    value: str
+    description: str | None = None
+
+    @field_validator("parameters")
+    @classmethod
+    def _require_unique_parameters(cls, parameters: list[str]) -> list[str]:
+        """Reject duplicate parameter declarations.
+
+        Args:
+            parameters: Parameter keys parsed from YAML.
+
+        Returns:
+            list[str]: The validated parameter keys.
+
+        Raises:
+            ValueError: If a parameter key appears more than once.
+        """
+        if len(parameters) != len(set(parameters)):
+            msg = "parameters must contain unique keys"
+            raise ValueError(msg)
+        return parameters
+
+
+class PromptTemplateSchemaError(ValueError):
+    """Raised when YAML data does not match the prompt-template schema."""
+
+    def __init__(self, *, path: Path, details: str) -> None:
+        """Initialize an error without exposing Pydantic in the public contract.
+
+        Args:
+            path: Path to the invalid YAML template.
+            details: Human-readable validation details.
+        """
+        self.path = path
+        msg = f"Prompt template {path} has an invalid YAML schema:\n{details}"
+        super().__init__(msg)
 
 
 class TemplateParameterError(ValueError):
@@ -117,77 +169,41 @@ def load_prompt_template(path: Path) -> PromptTemplate:
 
     Raises:
         FileNotFoundError: If *path* does not exist.
-        KeyError: If a required YAML key is absent.
-        TypeError: If a YAML field has the wrong type.
-        ValueError: If parameter declarations are duplicated or do not match
-            the Jinja template variables.
+        PromptTemplateSchemaError: If the YAML data does not match the schema,
+            including duplicate parameter declarations.
+        ValueError: If parameter declarations do not match the Jinja template
+            variables.
         yaml.YAMLError: If the file is not valid YAML.
     """
     with path.open(encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
-    if not isinstance(data, Mapping):
-        msg = f"Prompt template {path} must contain a YAML mapping."
-        raise TypeError(msg)
+    try:
+        definition = _PromptTemplateYaml.model_validate(data)
+    except ValidationError as exc:
+        raise PromptTemplateSchemaError(path=path, details=str(exc)) from exc
 
-    name = _required_string(data, "name", path=path)
-    value = _required_string(data, "value", path=path)
-    description = data.get("description")
-    if description is not None and not isinstance(description, str):
-        msg = f"Prompt template {path} field 'description' must be a string or null."
-        raise TypeError(msg)
-
-    if "parameters" not in data:
-        msg = f"Prompt template {path} is missing required field 'parameters'."
-        raise KeyError(msg)
-    raw_parameter_keys = data["parameters"]
-    if not isinstance(raw_parameter_keys, list) or not all(
-        isinstance(key, str) for key in raw_parameter_keys
-    ):
-        msg = f"Prompt template {path} field 'parameters' must be a list of strings."
-        raise TypeError(msg)
-    parameter_keys = tuple(raw_parameter_keys)
-    if len(parameter_keys) != len(set(parameter_keys)):
-        msg = f"Prompt template {path} field 'parameters' contains duplicate keys."
-        raise ValueError(msg)
-
-    parsed = _JINJA_ENVIRONMENT.parse(value, name=name, filename=str(path))
+    parameter_keys = tuple(definition.parameters)
+    parsed = _JINJA_ENVIRONMENT.parse(
+        definition.value,
+        name=definition.name,
+        filename=str(path),
+    )
     referenced_keys = meta.find_undeclared_variables(parsed)
     declared_keys = set(parameter_keys)
     if referenced_keys != declared_keys:
         missing = tuple(sorted(referenced_keys - declared_keys))
         unused = tuple(sorted(declared_keys - referenced_keys))
         msg = (
-            f"Prompt template {name!r} parameter declarations do not match its "
+            f"Prompt template {definition.name!r} parameter declarations do not match "
+            "its "
             f"Jinja variables: missing={missing!r}, unused={unused!r}"
         )
         raise ValueError(msg)
 
     return PromptTemplate(
-        name=name,
-        description=description,
+        name=definition.name,
+        description=definition.description,
         parameter_keys=parameter_keys,
         _template=_JINJA_ENVIRONMENT.from_string(parsed),
     )
-
-
-def _required_string(
-    data: Mapping[object, object],
-    key: str,
-    *,
-    path: Path,
-) -> str:
-    """Return a required string field from parsed YAML data.
-
-    Raises:
-        KeyError: If *key* is absent.
-        TypeError: If the field value is not a string.
-    """
-    if key not in data:
-        msg = f"Prompt template {path} is missing required field {key!r}."
-        raise KeyError(msg)
-    value = data[key]
-    if not isinstance(value, str):
-        msg = f"Prompt template {path} field {key!r} must be a string."
-        raise TypeError(msg)
-    return value

--- a/rampart/common/templates.py
+++ b/rampart/common/templates.py
@@ -4,43 +4,190 @@
 """YAML prompt-template loader shared by drivers and evaluators.
 
 RAMPART keeps prompt text in YAML files under per-package ``prompts/``
-directories.  Each file has a ``value`` key whose content is a Jinja2
-template string.  This module provides a single function to load,
-parse, and compile those templates so that every consumer uses the
-same logic and the same error surface.
+directories. Each file uses this schema:
+
+- ``name`` (required): Human-readable template name.
+- ``parameters`` (required): Exact keyword names accepted by ``render()``.
+- ``value`` (required): Jinja2 template source.
+- ``description`` (optional): Human-readable purpose; defaults to ``None``.
+
+The loader maps ``parameters`` to :attr:`PromptTemplate.parameter_keys`,
+compiles ``value``, and returns a structured template that validates every
+render call before evaluating Jinja markup.
 """
 
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import yaml
-from jinja2 import Template
+from jinja2 import Environment, StrictUndefined, Template, meta, select_autoescape
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def load_prompt_template(path: Path) -> Template:
-    """Load and compile a YAML prompt template as a Jinja2 ``Template``.
+_JINJA_ENVIRONMENT = Environment(
+    autoescape=select_autoescape(default_for_string=False, default=False),
+    undefined=StrictUndefined,
+)
 
-    The YAML file is expected to contain at least a ``value`` key whose
-    string content is valid Jinja2 markup.  Other metadata keys (e.g.
-    ``name``, ``description``, ``parameters``) are ignored by this
-    loader — they exist for human documentation.
+
+class TemplateParameterError(ValueError):
+    """Raised when render arguments do not match a template's declared keys."""
+
+    def __init__(
+        self,
+        *,
+        template_name: str,
+        missing: Collection[str],
+        unexpected: Collection[str],
+    ) -> None:
+        """Initialize a deterministic parameter-mismatch error.
+
+        Args:
+            template_name: Human-readable name of the template.
+            missing: Declared keys absent from the render call.
+            unexpected: Render keys not declared by the template.
+        """
+        self.template_name = template_name
+        self.missing = tuple(sorted(missing))
+        self.unexpected = tuple(sorted(unexpected))
+
+        details = []
+        if self.missing:
+            details.append(f"missing={self.missing!r}")
+        if self.unexpected:
+            details.append(f"unexpected={self.unexpected!r}")
+        joined_details = ", ".join(details)
+        msg = f"Prompt template {template_name!r} parameter mismatch: {joined_details}"
+        super().__init__(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class PromptTemplate:
+    """Compiled prompt template with metadata and an explicit render contract."""
+
+    name: str
+    description: str | None
+    parameter_keys: tuple[str, ...]
+    _template: Template = field(repr=False, compare=False)
+
+    def render(self, **kwargs: object) -> str:
+        """Render with exactly the declared keyword arguments.
+
+        Args:
+            **kwargs: Values keyed by :attr:`parameter_keys`.
+
+        Returns:
+            str: The rendered prompt text.
+
+        Raises:
+            TemplateParameterError: If any declared key is missing or any
+                undeclared key is provided.
+        """
+        expected = frozenset(self.parameter_keys)
+        provided = frozenset(kwargs)
+        missing = expected - provided
+        unexpected = provided - expected
+        if missing or unexpected:
+            raise TemplateParameterError(
+                template_name=self.name,
+                missing=missing,
+                unexpected=unexpected,
+            )
+        return self._template.render(**kwargs)
+
+
+def load_prompt_template(path: Path) -> PromptTemplate:
+    """Load and compile a structured YAML prompt template.
+
+    ``name``, ``parameters``, and ``value`` are required. ``description``
+    is optional. The declared parameters must exactly match the variables
+    referenced by the Jinja template.
 
     Args:
         path: Absolute path to the YAML template file
             (e.g. ``.../prompts/llm_judge.yaml``).
 
     Returns:
-        Template: A compiled Jinja2 ``Template`` ready for ``.render()``.
+        PromptTemplate: Structured metadata and a compiled template.
 
     Raises:
         FileNotFoundError: If *path* does not exist.
-        KeyError: If the YAML file does not contain a ``value`` key.
+        KeyError: If a required YAML key is absent.
+        TypeError: If a YAML field has the wrong type.
+        ValueError: If parameter declarations are duplicated or do not match
+            the Jinja template variables.
         yaml.YAMLError: If the file is not valid YAML.
     """
     with path.open(encoding="utf-8") as f:
         data = yaml.safe_load(f)
-    return Template(data["value"])
+
+    if not isinstance(data, Mapping):
+        msg = f"Prompt template {path} must contain a YAML mapping."
+        raise TypeError(msg)
+
+    name = _required_string(data, "name", path=path)
+    value = _required_string(data, "value", path=path)
+    description = data.get("description")
+    if description is not None and not isinstance(description, str):
+        msg = f"Prompt template {path} field 'description' must be a string or null."
+        raise TypeError(msg)
+
+    if "parameters" not in data:
+        msg = f"Prompt template {path} is missing required field 'parameters'."
+        raise KeyError(msg)
+    raw_parameter_keys = data["parameters"]
+    if not isinstance(raw_parameter_keys, list) or not all(
+        isinstance(key, str) for key in raw_parameter_keys
+    ):
+        msg = f"Prompt template {path} field 'parameters' must be a list of strings."
+        raise TypeError(msg)
+    parameter_keys = tuple(raw_parameter_keys)
+    if len(parameter_keys) != len(set(parameter_keys)):
+        msg = f"Prompt template {path} field 'parameters' contains duplicate keys."
+        raise ValueError(msg)
+
+    parsed = _JINJA_ENVIRONMENT.parse(value, name=name, filename=str(path))
+    referenced_keys = meta.find_undeclared_variables(parsed)
+    declared_keys = set(parameter_keys)
+    if referenced_keys != declared_keys:
+        missing = tuple(sorted(referenced_keys - declared_keys))
+        unused = tuple(sorted(declared_keys - referenced_keys))
+        msg = (
+            f"Prompt template {name!r} parameter declarations do not match its "
+            f"Jinja variables: missing={missing!r}, unused={unused!r}"
+        )
+        raise ValueError(msg)
+
+    return PromptTemplate(
+        name=name,
+        description=description,
+        parameter_keys=parameter_keys,
+        _template=_JINJA_ENVIRONMENT.from_string(parsed),
+    )
+
+
+def _required_string(
+    data: Mapping[object, object],
+    key: str,
+    *,
+    path: Path,
+) -> str:
+    """Return a required string field from parsed YAML data.
+
+    Raises:
+        KeyError: If *key* is absent.
+        TypeError: If the field value is not a string.
+    """
+    if key not in data:
+        msg = f"Prompt template {path} is missing required field {key!r}."
+        raise KeyError(msg)
+    value = data[key]
+    if not isinstance(value, str):
+        msg = f"Prompt template {path} field {key!r} must be a string."
+        raise TypeError(msg)
+    return value

--- a/rampart/common/templates.py
+++ b/rampart/common/templates.py
@@ -24,12 +24,19 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Annotated, TypeAlias, TypeVar
 
 import yaml
-from jinja2 import Environment, StrictUndefined, Template, meta, select_autoescape
+from jinja2 import (
+    Environment,
+    StrictUndefined,
+    Template,
+    TemplateError,
+    meta,
+    select_autoescape,
+)
 from pydantic import AfterValidator, BaseModel, ConfigDict, ValidationError
 
 __all__ = [
     "PromptTemplate",
-    "PromptTemplateSchemaError",
+    "PromptTemplateDefinitionError",
     "TemplateParameterError",
 ]
 
@@ -45,18 +52,18 @@ _JINJA_ENVIRONMENT = Environment(
 )
 
 
-class PromptTemplateSchemaError(ValueError):
-    """Raised when YAML data does not match the prompt-template schema."""
+class PromptTemplateDefinitionError(ValueError):
+    """Raised when file contents do not define a valid prompt template."""
 
     def __init__(self, *, path: Path, details: str) -> None:
-        """Initialize an error without exposing Pydantic in the public contract.
+        """Initialize an invalid-definition error.
 
         Args:
             path: Path to the invalid YAML template.
-            details: Human-readable validation details.
+            details: Human-readable failure details.
         """
         self.path = path
-        msg = f"Prompt template {path} has an invalid YAML schema:\n{details}"
+        msg = f"Prompt template {path} is invalid:\n{details}"
         super().__init__(msg)
 
 
@@ -116,11 +123,8 @@ class PromptTemplate:
 
         Raises:
             FileNotFoundError: If *path* does not exist.
-            PromptTemplateSchemaError: If the YAML data does not match the
-                schema, including duplicate parameter declarations.
-            ValueError: If parameter declarations do not match the Jinja
-                template variables.
-            yaml.YAMLError: If the file is not valid YAML.
+            PromptTemplateDefinitionError: If the file contents do not define
+                a valid prompt template.
         """
         definition = _load_yaml_definition(path)
         return cls(
@@ -210,17 +214,19 @@ def _load_yaml_definition(path: Path) -> _PromptTemplateYaml:
 
     Raises:
         FileNotFoundError: If *path* does not exist.
-        PromptTemplateSchemaError: If the YAML data does not match the schema,
-            including duplicate parameter declarations.
-        yaml.YAMLError: If the file is not valid YAML.
+        PromptTemplateDefinitionError: If the file is not valid UTF-8 or YAML,
+            or if its data does not match the template schema.
     """
-    with path.open(encoding="utf-8") as f:
-        data = yaml.safe_load(f)
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except (UnicodeError, yaml.YAMLError) as exc:
+        raise PromptTemplateDefinitionError(path=path, details=str(exc)) from exc
 
     try:
         return _PromptTemplateYaml.model_validate(data)
     except ValidationError as exc:
-        raise PromptTemplateSchemaError(path=path, details=str(exc)) from exc
+        raise PromptTemplateDefinitionError(path=path, details=str(exc)) from exc
 
 
 def _compile_template(
@@ -238,14 +244,19 @@ def _compile_template(
         Template: The compiled Jinja template.
 
     Raises:
-        ValueError: If declared parameters do not match the Jinja variables.
+        PromptTemplateDefinitionError: If the Jinja template is invalid or
+            declared parameters do not match its variables.
     """
-    parsed = _JINJA_ENVIRONMENT.parse(
-        definition.value,
-        name=definition.name,
-        filename=str(path),
-    )
-    referenced_keys = meta.find_undeclared_variables(parsed)
+    try:
+        parsed = _JINJA_ENVIRONMENT.parse(
+            definition.value,
+            name=definition.name,
+            filename=str(path),
+        )
+        referenced_keys = meta.find_undeclared_variables(parsed)
+    except TemplateError as exc:
+        raise PromptTemplateDefinitionError(path=path, details=str(exc)) from exc
+
     declared_keys = set(definition.parameters)
     if referenced_keys != declared_keys:
         missing = tuple(sorted(referenced_keys - declared_keys))
@@ -254,6 +265,9 @@ def _compile_template(
             f"Prompt template {definition.name!r} parameters do not match its "
             f"Jinja variables: missing={missing!r}, unused={unused!r}"
         )
-        raise ValueError(msg)
+        raise PromptTemplateDefinitionError(path=path, details=msg)
 
-    return _JINJA_ENVIRONMENT.from_string(parsed)
+    try:
+        return _JINJA_ENVIRONMENT.from_string(parsed)
+    except TemplateError as exc:
+        raise PromptTemplateDefinitionError(path=path, details=str(exc)) from exc

--- a/rampart/drivers/llm.py
+++ b/rampart/drivers/llm.py
@@ -36,7 +36,7 @@ from pyrit.exceptions import EmptyResponseException
 from pyrit.memory import CentralMemory
 from pyrit.prompt_normalizer import PromptNormalizer
 
-from rampart.common.templates import load_prompt_template
+from rampart.common.templates import PromptTemplate
 from rampart.core.errors import DriverError
 from rampart.core.prompt_driver import PromptDecision
 from rampart.core.types import Payload, Request, Turn
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
-_SYSTEM_PROMPT_TEMPLATE = load_prompt_template(
+_SYSTEM_PROMPT_TEMPLATE = PromptTemplate.from_yaml(
     _PROMPTS_DIR / "llm_driver_system_prompt.yaml",
 )
 

--- a/rampart/evaluators/llm_judge.py
+++ b/rampart/evaluators/llm_judge.py
@@ -22,7 +22,7 @@ from pyrit.exceptions import (
 )
 from pyrit.prompt_normalizer import PromptNormalizer
 
-from rampart.common.templates import load_prompt_template
+from rampart.common.templates import PromptTemplate
 from rampart.core.errors import EvaluatorError
 from rampart.core.evaluator import BaseEvaluator
 from rampart.core.types import EvalContext, EvalOutcome, EvalResult
@@ -60,7 +60,7 @@ class TranscriptScope(Enum):
 
 
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
-_SYSTEM_PROMPT_TEMPLATE = load_prompt_template(_PROMPTS_DIR / "llm_judge.yaml")
+_SYSTEM_PROMPT_TEMPLATE = PromptTemplate.from_yaml(_PROMPTS_DIR / "llm_judge.yaml")
 
 _ALLOWED_OUTCOMES: frozenset[str] = frozenset(
     {"detected", "not_detected", "undetermined"},

--- a/tests/unit/common/test_templates.py
+++ b/tests/unit/common/test_templates.py
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from rampart.common.templates import (
+    PromptTemplate,
+    TemplateParameterError,
+    load_prompt_template,
+)
+
+
+def _write_template(tmp_path: Path, **overrides: object) -> Path:
+    data: dict[str, object] = {
+        "name": "Greeting",
+        "parameters": ["subject"],
+        "value": "Hello, {{ subject }}!",
+    }
+    data.update(overrides)
+    path = tmp_path / "prompt.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+class TestLoadPromptTemplate:
+    def test_loads_metadata_and_renders_successfully(self, tmp_path: Path) -> None:
+        path = _write_template(tmp_path, description="Greets a subject.")
+
+        template = load_prompt_template(path)
+
+        assert isinstance(template, PromptTemplate)
+        assert template.name == "Greeting"
+        assert template.description == "Greets a subject."
+        assert template.parameter_keys == ("subject",)
+        assert template.render(subject="Ada") == "Hello, Ada!"
+
+    def test_optional_description_defaults_to_none(self, tmp_path: Path) -> None:
+        template = load_prompt_template(_write_template(tmp_path))
+
+        assert template.description is None
+
+    def test_rejects_missing_parameter(self, tmp_path: Path) -> None:
+        template = load_prompt_template(_write_template(tmp_path))
+
+        with pytest.raises(TemplateParameterError) as exc_info:
+            template.render()
+
+        assert exc_info.value.template_name == "Greeting"
+        assert exc_info.value.missing == ("subject",)
+        assert exc_info.value.unexpected == ()
+
+    def test_rejects_unexpected_parameter(self, tmp_path: Path) -> None:
+        template = load_prompt_template(_write_template(tmp_path))
+
+        with pytest.raises(TemplateParameterError) as exc_info:
+            template.render(subject="Ada", subejct="typo")
+
+        assert exc_info.value.missing == ()
+        assert exc_info.value.unexpected == ("subejct",)
+
+    def test_rejects_parameter_declaration_drift(self, tmp_path: Path) -> None:
+        path = _write_template(
+            tmp_path,
+            parameters=["declared_but_unused"],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"missing=\('subject',\), unused=\('declared_but_unused',\)",
+        ):
+            load_prompt_template(path)

--- a/tests/unit/common/test_templates.py
+++ b/tests/unit/common/test_templates.py
@@ -6,10 +6,11 @@ from textwrap import dedent
 
 import pytest
 import yaml
+from jinja2 import TemplateError
 
 from rampart.common.templates import (
     PromptTemplate,
-    PromptTemplateSchemaError,
+    PromptTemplateDefinitionError,
     TemplateParameterError,
 )
 
@@ -72,8 +73,10 @@ class TestPromptTemplateFromYaml:
             """,
         )
 
-        with pytest.raises(yaml.YAMLError):
+        with pytest.raises(PromptTemplateDefinitionError) as exc_info:
             PromptTemplate.from_yaml(path)
+
+        assert isinstance(exc_info.value.__cause__, yaml.YAMLError)
 
     @pytest.mark.parametrize(
         "content",
@@ -89,7 +92,7 @@ class TestPromptTemplateFromYaml:
     ) -> None:
         path = _write_raw_yaml(tmp_path, content)
 
-        with pytest.raises(PromptTemplateSchemaError) as exc_info:
+        with pytest.raises(PromptTemplateDefinitionError) as exc_info:
             PromptTemplate.from_yaml(path)
 
         assert exc_info.value.path == path
@@ -137,9 +140,32 @@ class TestPromptTemplateFromYaml:
         )
 
         with pytest.raises(
-            ValueError,
+            PromptTemplateDefinitionError,
             match=r"missing=\('subject',\), unused=\('declared_but_unused',\)",
         ):
+            PromptTemplate.from_yaml(path)
+
+    def test_wraps_invalid_jinja_syntax(self, tmp_path: Path) -> None:
+        path = _write_template(tmp_path, value="{{ subject")
+
+        with pytest.raises(PromptTemplateDefinitionError) as exc_info:
+            PromptTemplate.from_yaml(path)
+
+        assert isinstance(exc_info.value.__cause__, TemplateError)
+
+    def test_wraps_invalid_utf8(self, tmp_path: Path) -> None:
+        path = tmp_path / "prompt.yaml"
+        path.write_bytes(b"\xff")
+
+        with pytest.raises(PromptTemplateDefinitionError) as exc_info:
+            PromptTemplate.from_yaml(path)
+
+        assert isinstance(exc_info.value.__cause__, UnicodeDecodeError)
+
+    def test_preserves_missing_file_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "missing.yaml"
+
+        with pytest.raises(FileNotFoundError):
             PromptTemplate.from_yaml(path)
 
     @pytest.mark.parametrize(
@@ -184,7 +210,7 @@ class TestPromptTemplateFromYaml:
     ) -> None:
         path = _write_yaml(tmp_path, definition)
 
-        with pytest.raises(PromptTemplateSchemaError) as exc_info:
+        with pytest.raises(PromptTemplateDefinitionError) as exc_info:
             PromptTemplate.from_yaml(path)
 
         assert exc_info.value.path == path

--- a/tests/unit/common/test_templates.py
+++ b/tests/unit/common/test_templates.py
@@ -8,21 +8,26 @@ import yaml
 
 from rampart.common.templates import (
     PromptTemplate,
+    PromptTemplateSchemaError,
     TemplateParameterError,
     load_prompt_template,
 )
 
 
+def _write_yaml(tmp_path: Path, data: object) -> Path:
+    path = tmp_path / "prompt.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
 def _write_template(tmp_path: Path, **overrides: object) -> Path:
-    data: dict[str, object] = {
+    definition: dict[str, object] = {
         "name": "Greeting",
         "parameters": ["subject"],
         "value": "Hello, {{ subject }}!",
     }
-    data.update(overrides)
-    path = tmp_path / "prompt.yaml"
-    path.write_text(yaml.safe_dump(data), encoding="utf-8")
-    return path
+    definition.update(overrides)
+    return _write_yaml(tmp_path, definition)
 
 
 class TestLoadPromptTemplate:
@@ -72,3 +77,52 @@ class TestLoadPromptTemplate:
             match=r"missing=\('subject',\), unused=\('declared_but_unused',\)",
         ):
             load_prompt_template(path)
+
+    @pytest.mark.parametrize(
+        ("definition", "error_fragment"),
+        [
+            (
+                {"name": "Greeting", "value": "Hello!"},
+                "parameters",
+            ),
+            (
+                {
+                    "name": 42,
+                    "parameters": ["subject"],
+                    "value": "Hello, {{ subject }}!",
+                },
+                "name",
+            ),
+            (
+                {
+                    "name": "Greeting",
+                    "parameters": ["subject"],
+                    "value": "Hello, {{ subject }}!",
+                    "unexpected": True,
+                },
+                "unexpected",
+            ),
+            (
+                {
+                    "name": "Greeting",
+                    "parameters": ["subject", "subject"],
+                    "value": "Hello, {{ subject }}!",
+                },
+                "parameters must contain unique keys",
+            ),
+        ],
+    )
+    def test_rejects_invalid_yaml_schema(
+        self,
+        tmp_path: Path,
+        definition: object,
+        error_fragment: str,
+    ) -> None:
+        path = _write_yaml(tmp_path, definition)
+
+        with pytest.raises(PromptTemplateSchemaError) as exc_info:
+            load_prompt_template(path)
+
+        assert exc_info.value.path == path
+        assert error_fragment in str(exc_info.value)
+        assert exc_info.value.__cause__ is not None

--- a/tests/unit/common/test_templates.py
+++ b/tests/unit/common/test_templates.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 import yaml
@@ -10,13 +11,18 @@ from rampart.common.templates import (
     PromptTemplate,
     PromptTemplateSchemaError,
     TemplateParameterError,
-    load_prompt_template,
 )
 
 
 def _write_yaml(tmp_path: Path, data: object) -> Path:
     path = tmp_path / "prompt.yaml"
     path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+def _write_raw_yaml(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "prompt.yaml"
+    path.write_text(dedent(content), encoding="utf-8")
     return path
 
 
@@ -30,11 +36,69 @@ def _write_template(tmp_path: Path, **overrides: object) -> Path:
     return _write_yaml(tmp_path, definition)
 
 
-class TestLoadPromptTemplate:
+class TestPromptTemplateFromYaml:
+    def test_loads_raw_yaml_block_scalars(self, tmp_path: Path) -> None:
+        path = _write_raw_yaml(
+            tmp_path,
+            (
+                "name: Greeting\n"
+                "description: |\n"
+                "  Greets a subject across\n"
+                "  multiple lines.\n"
+                "parameters:\n"
+                "  - subject\n"
+                "value: |\n"
+                "  Hello, {{ subject }}!\n"
+                "  Welcome to RAMPART.\n"
+            ),
+        )
+
+        template = PromptTemplate.from_yaml(path)
+
+        assert template.name == "Greeting"
+        assert template.description == "Greets a subject across\nmultiple lines.\n"
+        assert template.parameter_keys == ("subject",)
+        assert template.render(subject="Ada") == "Hello, Ada!\nWelcome to RAMPART."
+
+    def test_rejects_malformed_raw_yaml(self, tmp_path: Path) -> None:
+        path = _write_raw_yaml(
+            tmp_path,
+            """\
+            name: Broken
+            parameters:
+              - subject
+            value: "{{ subject }}"
+            description: [unterminated
+            """,
+        )
+
+        with pytest.raises(yaml.YAMLError):
+            PromptTemplate.from_yaml(path)
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("- name\n- parameters\n- value\n", id="sequence"),
+        ],
+    )
+    def test_rejects_raw_yaml_without_mapping(
+        self,
+        tmp_path: Path,
+        content: str,
+    ) -> None:
+        path = _write_raw_yaml(tmp_path, content)
+
+        with pytest.raises(PromptTemplateSchemaError) as exc_info:
+            PromptTemplate.from_yaml(path)
+
+        assert exc_info.value.path == path
+        assert exc_info.value.__cause__ is not None
+
     def test_loads_metadata_and_renders_successfully(self, tmp_path: Path) -> None:
         path = _write_template(tmp_path, description="Greets a subject.")
 
-        template = load_prompt_template(path)
+        template = PromptTemplate.from_yaml(path)
 
         assert isinstance(template, PromptTemplate)
         assert template.name == "Greeting"
@@ -43,12 +107,12 @@ class TestLoadPromptTemplate:
         assert template.render(subject="Ada") == "Hello, Ada!"
 
     def test_optional_description_defaults_to_none(self, tmp_path: Path) -> None:
-        template = load_prompt_template(_write_template(tmp_path))
+        template = PromptTemplate.from_yaml(_write_template(tmp_path))
 
         assert template.description is None
 
     def test_rejects_missing_parameter(self, tmp_path: Path) -> None:
-        template = load_prompt_template(_write_template(tmp_path))
+        template = PromptTemplate.from_yaml(_write_template(tmp_path))
 
         with pytest.raises(TemplateParameterError) as exc_info:
             template.render()
@@ -58,7 +122,7 @@ class TestLoadPromptTemplate:
         assert exc_info.value.unexpected == ()
 
     def test_rejects_unexpected_parameter(self, tmp_path: Path) -> None:
-        template = load_prompt_template(_write_template(tmp_path))
+        template = PromptTemplate.from_yaml(_write_template(tmp_path))
 
         with pytest.raises(TemplateParameterError) as exc_info:
             template.render(subject="Ada", subejct="typo")
@@ -76,7 +140,7 @@ class TestLoadPromptTemplate:
             ValueError,
             match=r"missing=\('subject',\), unused=\('declared_but_unused',\)",
         ):
-            load_prompt_template(path)
+            PromptTemplate.from_yaml(path)
 
     @pytest.mark.parametrize(
         ("definition", "error_fragment"),
@@ -108,7 +172,7 @@ class TestLoadPromptTemplate:
                     "parameters": ["subject", "subject"],
                     "value": "Hello, {{ subject }}!",
                 },
-                "parameters must contain unique keys",
+                "items must be unique",
             ),
         ],
     )
@@ -121,7 +185,7 @@ class TestLoadPromptTemplate:
         path = _write_yaml(tmp_path, definition)
 
         with pytest.raises(PromptTemplateSchemaError) as exc_info:
-            load_prompt_template(path)
+            PromptTemplate.from_yaml(path)
 
         assert exc_info.value.path == path
         assert error_fragment in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -3001,6 +3001,7 @@ version = "0.1.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
+    { name = "pydantic" },
     { name = "pyrit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -3034,6 +3035,7 @@ requires-dist = [
     { name = "azure-identity", marker = "extra == 'onedrive'", specifier = ">=1.25.3" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "msgraph-sdk", marker = "extra == 'onedrive'", specifier = ">=1.57.0" },
+    { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pyrit", git = "https://github.com/microsoft/PyRIT?rev=6dc8b94139757390286bbce7d53c1f7e58e66e29" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },


### PR DESCRIPTION
## Description

Adds a structured `PromptTemplate` model with validated YAML loading and rendering.

- Replaces bare `jinja2.Template` loading with `PromptTemplate.from_yaml()`.
- Validates YAML through a strict private Pydantic schema.
- Rejects missing and unexpected render arguments.
- Verifies declared parameters against Jinja AST variables.
- Migrates `LLMDriver` and `LLMJudge` to the structured template API.
- Adds coverage for rendering, schema failures, parameter drift, block scalars, malformed YAML, and non-mapping YAML.

## Breaking changes

`load_prompt_template()` has been removed in favor of `PromptTemplate.from_yaml()`.

The loader now returns a `PromptTemplate` rather than a `jinja2.Template`; callers using Jinja-specific APIs must migrate to the structured API.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Tests added or updated for structured loading, rendering validation, schema failures, and raw YAML
- [x] Documentation updated in the prompt-template module docstring