### PR TITLE
[FIX]: Make Result.safe a derived property

### DIFF
--- a/docs/contributing/extending-rampart.md
+++ b/docs/contributing/extending-rampart.md
@@ -107,10 +107,9 @@ class MyAttackExecution(BaseExecution):
 
         # Use resolve_as_attack: detected → UNSAFE
         eval_results = [t.eval_result for t in turns if t.eval_result is not None]
-        safe, status = resolve_as_attack(eval_results=eval_results)
+        status = resolve_as_attack(eval_results=eval_results)
 
         return Result(
-            safe=safe,
             status=status,
             summary="...",
             turns=turns,
@@ -198,8 +197,8 @@ The file structure mirrors the [Attack walkthrough](#1-create-the-execution-clas
 -    return "my_attack"
 +    return "my_probe"
 
--    safe, status = resolve_as_attack(eval_results=eval_results)
-+    safe, status = resolve_as_probe(eval_results=eval_results)
+-    status = resolve_as_attack(eval_results=eval_results)
++    status = resolve_as_probe(eval_results=eval_results)
 ```
 
 Place the file in `rampart/probes/` (e.g. `_my_probe.py`). Most probes skip the injection phase — just session creation, prompt driving, and evaluation. For a complete working reference, see [`rampart/probes/_single_turn.py`](https://github.com/microsoft/RAMPART/blob/main/rampart/probes/_single_turn.py).

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -78,7 +78,6 @@ Define small private helper functions at the top of test files instead of fixtur
 def _make_result(*, safe: bool = True) -> Result:
     """Build a minimal Result for testing."""
     return Result(
-        safe=safe,
         status=SafetyStatus.SAFE if safe else SafetyStatus.UNSAFE,
         summary="test",
         strategy="test",

--- a/docs/usage/pytest-integration.md
+++ b/docs/usage/pytest-integration.md
@@ -165,7 +165,6 @@ from rampart import Result, SafetyStatus, record_result
 
 async def test_manual_result():
     result = Result(
-        safe=True,
         status=SafetyStatus.SAFE,
         summary="Agent passed manual check",
     )

--- a/rampart/attacks/_xpia.py
+++ b/rampart/attacks/_xpia.py
@@ -189,18 +189,16 @@ class XPIAExecution(BaseExecution):
             Result: The final safety verdict.
         """
         eval_results = [t.eval_result for t in turns if t.eval_result is not None]
-        safe, status = resolve_as_attack(eval_results=eval_results)
+        status = resolve_as_attack(eval_results=eval_results)
 
         if status == SafetyStatus.SAFE:
-            safe, status = self._adjust_for_observability(
+            status = self._adjust_for_observability(
                 adapter=adapter,
                 turns=turns,
-                safe=safe,
                 status=status,
             )
 
         return Result(
-            safe=safe,
             status=status,
             summary=_build_summary(status=status, eval_results=eval_results),
             turns=turns,
@@ -230,9 +228,8 @@ class XPIAExecution(BaseExecution):
         *,
         adapter: AgentAdapter,
         turns: list[Turn],
-        safe: bool,
         status: SafetyStatus,
-    ) -> tuple[bool, SafetyStatus]:
+    ) -> SafetyStatus:
         """Downgrade SAFE to UNDETERMINED when the adapter lacks observability.
 
         If the evaluator returned NOT_DETECTED (and ``resolve_as_attack``
@@ -249,22 +246,21 @@ class XPIAExecution(BaseExecution):
         Args:
             adapter (AgentAdapter): The adapter under test.
             turns (list[Turn]): Conversation history.
-            safe (bool): Current safety verdict.
             status (SafetyStatus): Current status.
 
         Returns:
-            tuple[bool, SafetyStatus]: Adjusted (safe, status).
+            SafetyStatus: The adjusted status.
         """
         if status != SafetyStatus.SAFE:
-            return safe, status
+            return status
 
         if adapter.observability_profile != ObservabilityLevel.RESPONSE_ONLY:
-            return safe, status
+            return status
 
         if any(t.response.tool_calls for t in turns):
-            return safe, status
+            return status
 
-        return False, SafetyStatus.UNDETERMINED
+        return SafetyStatus.UNDETERMINED
 
 
 def _collect_response_metadata(

--- a/rampart/core/execution.py
+++ b/rampart/core/execution.py
@@ -255,7 +255,6 @@ class BaseExecution(ABC):
             )
 
             result = Result(
-                safe=False,
                 status=SafetyStatus.ERROR,
                 summary=f"{error_type}: {exc}",
                 strategy=self.strategy_name,

--- a/rampart/core/result.py
+++ b/rampart/core/result.py
@@ -101,8 +101,10 @@ class Result:
     agent behaved safely" — and failures include the summary explaining
     what was detected.
 
+    ``safe`` is a derived property (``status is SafetyStatus.SAFE``),
+    not a stored field, so it can never drift out of sync with ``status``.
+
     Args:
-        safe: Whether the agent behaved safely. True = safe.
         status: Categorical status for structured reporting.
         summary: Human-readable one-line summary.
         turns: The full conversation for evidence and debugging.
@@ -118,7 +120,6 @@ class Result:
         metadata: Additional structured data for reporting.
     """
 
-    safe: bool
     status: SafetyStatus
     summary: str
     turns: list[Turn] = field(default_factory=list[Turn])
@@ -130,6 +131,15 @@ class Result:
         default_factory=list[InjectionRecord],
     )
     metadata: dict[str, Any] = field(default_factory=dict[str, Any])
+
+    @property
+    def safe(self) -> bool:
+        """Whether the agent behaved safely (``status is SafetyStatus.SAFE``).
+
+        Returns:
+            bool: True when the status is SAFE.
+        """
+        return self.status is SafetyStatus.SAFE
 
     @property
     def eval_results(self) -> list[EvalResult]:
@@ -158,7 +168,7 @@ class Result:
         )
 
 
-def resolve_as_attack(*, eval_results: list[EvalResult]) -> tuple[bool, SafetyStatus]:
+def resolve_as_attack(*, eval_results: list[EvalResult]) -> SafetyStatus:
     """Attack semantics: detected -> UNSAFE, not detected -> SAFE.
 
     Shared by all attack execution strategies (XPIA, prompt injection,
@@ -174,18 +184,18 @@ def resolve_as_attack(*, eval_results: list[EvalResult]) -> tuple[bool, SafetySt
         eval_results: List of evaluator outcomes.
 
     Returns:
-        Tuple of (safe, status).
+        SafetyStatus: The resolved status.
     """
     if not eval_results:
-        return False, SafetyStatus.ERROR
+        return SafetyStatus.ERROR
     if any(er.detected for er in eval_results):
-        return False, SafetyStatus.UNSAFE
+        return SafetyStatus.UNSAFE
     if any(er.outcome == EvalOutcome.UNDETERMINED for er in eval_results):
-        return False, SafetyStatus.UNDETERMINED
-    return True, SafetyStatus.SAFE
+        return SafetyStatus.UNDETERMINED
+    return SafetyStatus.SAFE
 
 
-def resolve_as_probe(*, eval_results: list[EvalResult]) -> tuple[bool, SafetyStatus]:
+def resolve_as_probe(*, eval_results: list[EvalResult]) -> SafetyStatus:
     """Probe semantics: detected -> SAFE, not detected -> UNSAFE.
 
     Shared by all probe execution strategies.
@@ -200,12 +210,12 @@ def resolve_as_probe(*, eval_results: list[EvalResult]) -> tuple[bool, SafetySta
         eval_results: List of evaluator outcomes.
 
     Returns:
-        Tuple of (safe, status).
+        SafetyStatus: The resolved status.
     """
     if not eval_results:
-        return False, SafetyStatus.ERROR
+        return SafetyStatus.ERROR
     if any(er.outcome == EvalOutcome.NOT_DETECTED for er in eval_results):
-        return False, SafetyStatus.UNSAFE
+        return SafetyStatus.UNSAFE
     if any(er.outcome == EvalOutcome.UNDETERMINED for er in eval_results):
-        return False, SafetyStatus.UNDETERMINED
-    return True, SafetyStatus.SAFE
+        return SafetyStatus.UNDETERMINED
+    return SafetyStatus.SAFE

--- a/rampart/probes/_single_turn.py
+++ b/rampart/probes/_single_turn.py
@@ -98,10 +98,9 @@ class SingleTurnExecution(BaseExecution):
                     break
 
         eval_results = [t.eval_result for t in turns if t.eval_result is not None]
-        safe, status = resolve_as_probe(eval_results=eval_results)
+        status = resolve_as_probe(eval_results=eval_results)
 
         return Result(
-            safe=safe,
             status=status,
             summary=_build_summary(status=status, eval_results=eval_results),
             turns=turns,

--- a/rampart/pytest_plugin/_xdist.py
+++ b/rampart/pytest_plugin/_xdist.py
@@ -921,7 +921,6 @@ def _deserialize_result(*, data: object) -> Result:
         else 0.0
     )
     return Result(
-        safe=bool(typed.get("safe", False)),
         status=_deserialize_safety_status(value=typed.get("status")),
         summary=_strip_ansi(text=str(typed.get("summary", ""))),
         turns=[

--- a/tests/unit/core/test_execution.py
+++ b/tests/unit/core/test_execution.py
@@ -73,7 +73,7 @@ class _SuccessExecution(BaseExecution):
 
     async def _execute_async(self, *, adapter: AgentAdapter) -> Result:
         """Return a safe result."""
-        return Result(safe=True, status=SafetyStatus.SAFE, summary="ok")
+        return Result(status=SafetyStatus.SAFE, summary="ok")
 
 
 class _InfraErrorExecution(BaseExecution):

--- a/tests/unit/core/test_result.py
+++ b/tests/unit/core/test_result.py
@@ -79,19 +79,18 @@ class TestInjectionRecord:
 
 class TestResult:
     def test_bool_returns_safe_true(self) -> None:
-        r = Result(safe=True, status=SafetyStatus.SAFE, summary="ok")
+        r = Result(status=SafetyStatus.SAFE, summary="ok")
         assert bool(r) is True
 
     def test_bool_returns_safe_false(self) -> None:
-        r = Result(safe=False, status=SafetyStatus.UNSAFE, summary="bad")
+        r = Result(status=SafetyStatus.UNSAFE, summary="bad")
         assert bool(r) is False
 
     def test_assert_safe_pattern(self) -> None:
-        safe_result = Result(safe=True, status=SafetyStatus.SAFE, summary="ok")
+        safe_result = Result(status=SafetyStatus.SAFE, summary="ok")
         assert safe_result, safe_result.summary
 
         unsafe_result = Result(
-            safe=False,
             status=SafetyStatus.UNSAFE,
             summary="attack detected",
         )
@@ -99,13 +98,13 @@ class TestResult:
             assert unsafe_result, unsafe_result.summary
 
     def test_repr(self) -> None:
-        r = Result(safe=True, status=SafetyStatus.SAFE, summary="Agent defended")
+        r = Result(status=SafetyStatus.SAFE, summary="Agent defended")
         assert "safe=True" in repr(r)
         assert "safe" in repr(r)
         assert "Agent defended" in repr(r)
 
     def test_defaults(self) -> None:
-        r = Result(safe=True, status=SafetyStatus.SAFE, summary="ok")
+        r = Result(status=SafetyStatus.SAFE, summary="ok")
         assert r.turns == []
         assert r.eval_results == []
         assert r.duration_seconds == pytest.approx(0.0)
@@ -117,7 +116,6 @@ class TestResult:
 
     def test_harm_category_accepts_enum(self) -> None:
         r = Result(
-            safe=True,
             status=SafetyStatus.SAFE,
             summary="ok",
             harm_category=HarmCategory.DATA_EXFILTRATION,
@@ -127,7 +125,6 @@ class TestResult:
 
     def test_harm_category_accepts_plain_string(self) -> None:
         r = Result(
-            safe=True,
             status=SafetyStatus.SAFE,
             summary="ok",
             harm_category="custom_product_risk",
@@ -139,7 +136,7 @@ class TestResultEvalResultsProperty:
     """eval_results is a property derived from turns."""
 
     def test_empty_turns_gives_empty_eval_results(self) -> None:
-        r = Result(safe=True, status=SafetyStatus.SAFE, summary="ok")
+        r = Result(status=SafetyStatus.SAFE, summary="ok")
         assert r.eval_results == []
 
     def test_turns_with_eval_results_returned_in_order(self) -> None:
@@ -158,7 +155,6 @@ class TestResultEvalResultsProperty:
             ),
         ]
         r = Result(
-            safe=False,
             status=SafetyStatus.UNSAFE,
             summary="bad",
             turns=turns,
@@ -179,7 +175,6 @@ class TestResultEvalResultsProperty:
             ),
         ]
         r = Result(
-            safe=False,
             status=SafetyStatus.UNSAFE,
             summary="bad",
             turns=turns,
@@ -189,115 +184,101 @@ class TestResultEvalResultsProperty:
 
 class TestResolveAsAttack:
     def test_empty_returns_error(self) -> None:
-        safe, status = resolve_as_attack(eval_results=[])
-        assert safe is False
+        status = resolve_as_attack(eval_results=[])
         assert status is SafetyStatus.ERROR
 
     def test_detected_returns_unsafe(self) -> None:
-        safe, status = resolve_as_attack(
+        status = resolve_as_attack(
             eval_results=[_er(EvalOutcome.DETECTED)],
         )
-        assert safe is False
         assert status is SafetyStatus.UNSAFE
 
     def test_not_detected_returns_safe(self) -> None:
-        safe, status = resolve_as_attack(
+        status = resolve_as_attack(
             eval_results=[_er(EvalOutcome.NOT_DETECTED)],
         )
-        assert safe is True
         assert status is SafetyStatus.SAFE
 
     def test_undetermined_only_returns_undetermined(self) -> None:
-        safe, status = resolve_as_attack(
+        status = resolve_as_attack(
             eval_results=[_er(EvalOutcome.UNDETERMINED)],
         )
-        assert safe is False
         assert status is SafetyStatus.UNDETERMINED
 
     def test_mixed_detected_and_undetermined_returns_unsafe(self) -> None:
-        safe, status = resolve_as_attack(
+        status = resolve_as_attack(
             eval_results=[
                 _er(EvalOutcome.UNDETERMINED),
                 _er(EvalOutcome.DETECTED),
             ],
         )
-        assert safe is False
         assert status is SafetyStatus.UNSAFE
 
     def test_mixed_not_detected_and_undetermined_returns_undetermined(self) -> None:
-        safe, status = resolve_as_attack(
+        status = resolve_as_attack(
             eval_results=[
                 _er(EvalOutcome.NOT_DETECTED),
                 _er(EvalOutcome.UNDETERMINED),
             ],
         )
-        assert safe is False
         assert status is SafetyStatus.UNDETERMINED
 
     def test_all_not_detected_returns_safe(self) -> None:
-        safe, status = resolve_as_attack(
+        status = resolve_as_attack(
             eval_results=[
                 _er(EvalOutcome.NOT_DETECTED),
                 _er(EvalOutcome.NOT_DETECTED),
             ],
         )
-        assert safe is True
         assert status is SafetyStatus.SAFE
 
 
 class TestResolveAsProbe:
     def test_empty_returns_error(self) -> None:
-        safe, status = resolve_as_probe(eval_results=[])
-        assert safe is False
+        status = resolve_as_probe(eval_results=[])
         assert status is SafetyStatus.ERROR
 
     def test_detected_returns_safe(self) -> None:
-        safe, status = resolve_as_probe(
+        status = resolve_as_probe(
             eval_results=[_er(EvalOutcome.DETECTED)],
         )
-        assert safe is True
         assert status is SafetyStatus.SAFE
 
     def test_not_detected_returns_unsafe(self) -> None:
-        safe, status = resolve_as_probe(
+        status = resolve_as_probe(
             eval_results=[_er(EvalOutcome.NOT_DETECTED)],
         )
-        assert safe is False
         assert status is SafetyStatus.UNSAFE
 
     def test_undetermined_only_returns_undetermined(self) -> None:
-        safe, status = resolve_as_probe(
+        status = resolve_as_probe(
             eval_results=[_er(EvalOutcome.UNDETERMINED)],
         )
-        assert safe is False
         assert status is SafetyStatus.UNDETERMINED
 
     def test_mixed_not_detected_and_undetermined_returns_unsafe(self) -> None:
-        safe, status = resolve_as_probe(
+        status = resolve_as_probe(
             eval_results=[
                 _er(EvalOutcome.UNDETERMINED),
                 _er(EvalOutcome.NOT_DETECTED),
             ],
         )
-        assert safe is False
         assert status is SafetyStatus.UNSAFE
 
     def test_mixed_detected_and_undetermined_returns_undetermined(self) -> None:
-        safe, status = resolve_as_probe(
+        status = resolve_as_probe(
             eval_results=[
                 _er(EvalOutcome.DETECTED),
                 _er(EvalOutcome.UNDETERMINED),
             ],
         )
-        assert safe is False
         assert status is SafetyStatus.UNDETERMINED
 
     def test_all_detected_returns_safe(self) -> None:
-        safe, status = resolve_as_probe(
+        status = resolve_as_probe(
             eval_results=[
                 _er(EvalOutcome.DETECTED),
                 _er(EvalOutcome.DETECTED),
             ],
         )
-        assert safe is True
         assert status is SafetyStatus.SAFE

--- a/tests/unit/pytest_plugin/test_collection.py
+++ b/tests/unit/pytest_plugin/test_collection.py
@@ -21,7 +21,7 @@ from rampart.pytest_plugin._collection import (
 
 def _make_result(*, summary: str = "test") -> Result:
     """Build a minimal Result for testing."""
-    return Result(safe=True, status=SafetyStatus.SAFE, summary=summary)
+    return Result(status=SafetyStatus.SAFE, summary=summary)
 
 
 def _make_event_data(

--- a/tests/unit/pytest_plugin/test_plugin.py
+++ b/tests/unit/pytest_plugin/test_plugin.py
@@ -126,7 +126,7 @@ class TestRampartSession:
         session = RampartSession()
         collector = ResultCollector()
         collector.record(
-            result=Result(safe=True, status=SafetyStatus.SAFE, summary="ok"),
+            result=Result(status=SafetyStatus.SAFE, summary="ok"),
         )
         node = MagicMock()
         node.nodeid = "test_file.py::test_absorb"
@@ -147,13 +147,13 @@ class TestRampartSession:
 
         collector = ResultCollector()
         collector.record(
-            result=Result(safe=True, status=SafetyStatus.SAFE, summary="s"),
+            result=Result(status=SafetyStatus.SAFE, summary="s"),
         )
         collector.record(
-            result=Result(safe=False, status=SafetyStatus.UNSAFE, summary="u"),
+            result=Result(status=SafetyStatus.UNSAFE, summary="u"),
         )
         collector.record(
-            result=Result(safe=False, status=SafetyStatus.ERROR, summary="e"),
+            result=Result(status=SafetyStatus.ERROR, summary="e"),
         )
         node = MagicMock()
         node.nodeid = "test_file.py::test_counts"
@@ -182,7 +182,6 @@ class TestRampartSession:
             collector = ResultCollector()
             collector.record(
                 result=Result(
-                    safe=statuses[idx] == SafetyStatus.SAFE,
                     status=statuses[idx],
                     summary=f"trial-{idx}",
                 ),
@@ -215,7 +214,6 @@ class TestRampartSession:
             collector = ResultCollector()
             collector.record(
                 result=Result(
-                    safe=False,
                     status=SafetyStatus.ERROR,
                     summary=f"err-{idx}",
                 ),
@@ -249,7 +247,6 @@ class TestRampartSession:
             collector = ResultCollector()
             collector.record(
                 result=Result(
-                    safe=statuses[idx] == SafetyStatus.SAFE,
                     status=statuses[idx],
                     summary=f"trial-{idx}",
                 ),
@@ -277,7 +274,6 @@ class TestRampartSession:
             collector = ResultCollector()
             collector.record(
                 result=Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary=f"trial-{idx}",
                 ),
@@ -488,7 +484,6 @@ class TestWriteResultLine:
     def test_safe_result_includes_observability(self) -> None:
         reporter = MagicMock()
         result = Result(
-            safe=True,
             status=SafetyStatus.SAFE,
             summary="ok",
             observability_level=ObservabilityLevel.RESPONSE_ONLY,
@@ -502,7 +497,6 @@ class TestWriteResultLine:
     def test_unsafe_result_includes_observability(self) -> None:
         reporter = MagicMock()
         result = Result(
-            safe=False,
             status=SafetyStatus.UNSAFE,
             summary="bad",
             observability_level=ObservabilityLevel.TOOL_AND_SIDE_EFFECTS,
@@ -518,7 +512,6 @@ class TestWriteResultLine:
     def test_with_test_name(self) -> None:
         reporter = MagicMock()
         result = Result(
-            safe=True,
             status=SafetyStatus.SAFE,
             summary="SAFE",
             observability_level=ObservabilityLevel.TOOL_ONLY,
@@ -535,7 +528,6 @@ class TestWriteResultLine:
     def test_ansi_stripped_from_summary(self) -> None:
         reporter = MagicMock()
         result = Result(
-            safe=True,
             status=SafetyStatus.SAFE,
             summary="\x1b[31mevil\x1b[0m",
         )
@@ -557,7 +549,6 @@ class TestTerminalSummary:
         collector = ResultCollector()
         collector.record(
             result=Result(
-                safe=True,
                 status=SafetyStatus.SAFE,
                 summary="safe-one",
                 harm_category="data_exfiltration",
@@ -565,7 +556,6 @@ class TestTerminalSummary:
         )
         collector.record(
             result=Result(
-                safe=False,
                 status=SafetyStatus.UNSAFE,
                 summary="unsafe-one",
                 harm_category="jailbreak",
@@ -724,7 +714,7 @@ class TestRampartSessionDuration:
         session = RampartSession()
         collector = ResultCollector()
         collector.record(
-            result=Result(safe=True, status=SafetyStatus.SAFE, summary="ok"),
+            result=Result(status=SafetyStatus.SAFE, summary="ok"),
         )
         node = MagicMock()
         node.nodeid = "test.py::test_dur"
@@ -736,7 +726,7 @@ class TestRampartSessionDuration:
         session = RampartSession()
         collector = ResultCollector()
         collector.record(
-            result=Result(safe=True, status=SafetyStatus.SAFE, summary="ok"),
+            result=Result(status=SafetyStatus.SAFE, summary="ok"),
         )
         node = MagicMock()
         node.nodeid = "test.py::test_dur"
@@ -758,7 +748,6 @@ class TestTrialGroupRendering:
             status = SafetyStatus.UNSAFE if idx < 2 else SafetyStatus.SAFE
             collector.record(
                 result=Result(
-                    safe=status == SafetyStatus.SAFE,
                     status=status,
                     summary=f"t-{idx}",
                 ),
@@ -791,7 +780,6 @@ class TestTrialGroupRendering:
             collector = ResultCollector()
             collector.record(
                 result=Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary=f"t-{idx}",
                 ),
@@ -838,7 +826,6 @@ class TestEvaluateGates:
             status = SafetyStatus.UNSAFE if idx < 2 else SafetyStatus.SAFE
             collector.record(
                 result=Result(
-                    safe=status == SafetyStatus.SAFE,
                     status=status,
                     summary=f"t-{idx}",
                 ),
@@ -868,7 +855,7 @@ class TestEmitSinks:
         session = RampartSession(sinks=[mock_sink])
         collector = ResultCollector()
         collector.record(
-            result=Result(safe=True, status=SafetyStatus.SAFE, summary="ok"),
+            result=Result(status=SafetyStatus.SAFE, summary="ok"),
         )
         node = MagicMock()
         node.nodeid = "test.py::test_sink"

--- a/tests/unit/pytest_plugin/test_xdist.py
+++ b/tests/unit/pytest_plugin/test_xdist.py
@@ -59,7 +59,6 @@ from rampart.reporting.sink import ReportSink, TestRunReport
 
 def _make_result(
     *,
-    safe: bool = True,
     status: SafetyStatus = SafetyStatus.SAFE,
     summary: str = "summary",
     harm_category: HarmCategory | str | None = None,
@@ -71,7 +70,6 @@ def _make_result(
     observability_level: ObservabilityLevel = ObservabilityLevel.RESPONSE_ONLY,
 ) -> Result:
     return Result(
-        safe=safe,
         status=status,
         summary=summary,
         turns=turns or [],
@@ -283,7 +281,7 @@ class TestSerializationRoundTrip:
 
     def test_status_enum_round_trip(self) -> None:
         for status in SafetyStatus:
-            result = _make_result(status=status, safe=status is SafetyStatus.SAFE)
+            result = _make_result(status=status)
             session = _make_session_with_results(
                 results_by_nodeid={"n": [result]},
             )

--- a/tests/unit/pytest_plugin/test_xdist_aggregation.py
+++ b/tests/unit/pytest_plugin/test_xdist_aggregation.py
@@ -95,14 +95,14 @@ def _setup_simple_tests(configured_pytester: Pytester) -> None:
         @pytest.mark.harm("test")
         def test_a_one():
             record_result(Result(
-                safe=True, status=SafetyStatus.SAFE, summary="a1",
+                status=SafetyStatus.SAFE, summary="a1",
                 observability_level=ObservabilityLevel.RESPONSE_ONLY,
             ))
 
         @pytest.mark.harm("test")
         def test_a_two():
             record_result(Result(
-                safe=False, status=SafetyStatus.UNSAFE, summary="a2",
+                status=SafetyStatus.UNSAFE, summary="a2",
                 observability_level=ObservabilityLevel.RESPONSE_ONLY,
             ))
         """,
@@ -115,14 +115,14 @@ def _setup_simple_tests(configured_pytester: Pytester) -> None:
         @pytest.mark.harm("test")
         def test_b_one():
             record_result(Result(
-                safe=True, status=SafetyStatus.SAFE, summary="b1",
+                status=SafetyStatus.SAFE, summary="b1",
                 observability_level=ObservabilityLevel.RESPONSE_ONLY,
             ))
 
         @pytest.mark.harm("test")
         def test_b_two():
             record_result(Result(
-                safe=True, status=SafetyStatus.SAFE, summary="b2",
+                status=SafetyStatus.SAFE, summary="b2",
                 observability_level=ObservabilityLevel.RESPONSE_ONLY,
             ))
         """,
@@ -189,7 +189,7 @@ class TestXdistTrialAggregation:
             @pytest.mark.trial(n=4, threshold=0.5)
             def test_trial_split():
                 record_result(Result(
-                    safe=True, status=SafetyStatus.SAFE, summary="t",
+                    status=SafetyStatus.SAFE, summary="t",
                     observability_level=ObservabilityLevel.RESPONSE_ONLY,
                 ))
             """,
@@ -222,7 +222,7 @@ class TestXdistTrialAggregation:
             @pytest.mark.trial(n=4, threshold=0.5)
             def test_trial_split():
                 record_result(Result(
-                    safe=True, status=SafetyStatus.SAFE, summary="t",
+                    status=SafetyStatus.SAFE, summary="t",
                     observability_level=ObservabilityLevel.RESPONSE_ONLY,
                 ))
             """,
@@ -263,7 +263,6 @@ class TestXdistTrialAggregation:
             def test_trial_mixed_load(request):
                 unsafe = request.node.name.endswith("[trial-3]")
                 record_result(Result(
-                    safe=not unsafe,
                     status=SafetyStatus.UNSAFE if unsafe else SafetyStatus.SAFE,
                     summary="u" if unsafe else "s",
                     observability_level=ObservabilityLevel.RESPONSE_ONLY,

--- a/tests/unit/reporting/test_json_file.py
+++ b/tests/unit/reporting/test_json_file.py
@@ -41,7 +41,6 @@ def _result_with_turns(
         turn_number=0,
     )
     return Result(
-        safe=True,
         status=SafetyStatus.SAFE,
         summary="ok",
         turns=[turn],
@@ -95,7 +94,6 @@ class TestSerializeResult:
         )
         turn = Turn(request=Request(prompt="hi"), response=response, turn_number=0)
         result = Result(
-            safe=False,
             status=SafetyStatus.UNSAFE,
             summary="memory poisoned",
             turns=[turn],
@@ -129,7 +127,6 @@ class TestSerializeResult:
         )
         turn = Turn(request=Request(prompt="hi"), response=response, turn_number=0)
         result = Result(
-            safe=False,
             status=SafetyStatus.UNSAFE,
             summary="exfiltration",
             turns=[turn],
@@ -155,7 +152,6 @@ class TestSerializeResult:
             ),
         )
         result = Result(
-            safe=False,
             status=SafetyStatus.UNSAFE,
             summary="bad",
             turns=[turn],
@@ -186,7 +182,6 @@ class TestSerializeResult:
             driver_reasoning="Trying a different angle",
         )
         result = Result(
-            safe=True,
             status=SafetyStatus.SAFE,
             summary="ok",
             turns=[turn],

--- a/tests/unit/reporting/test_report.py
+++ b/tests/unit/reporting/test_report.py
@@ -35,19 +35,16 @@ class TestByHarmCategory:
         report = TestRunReport(
             results=[
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="ok",
                     harm_category=HarmCategory.DATA_EXFILTRATION,
                 ),
                 Result(
-                    safe=False,
                     status=SafetyStatus.UNSAFE,
                     summary="bad",
                     harm_category=HarmCategory.DATA_EXFILTRATION,
                 ),
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="ok2",
                     harm_category=HarmCategory.JAILBREAK,
@@ -63,13 +60,11 @@ class TestByHarmCategory:
         report = TestRunReport(
             results=[
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="ok",
                     harm_category="custom_risk",
                 ),
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="ok2",
                     harm_category="custom_risk",
@@ -84,7 +79,6 @@ class TestByHarmCategory:
         report = TestRunReport(
             results=[
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="ok",
                     harm_category=None,
@@ -100,19 +94,16 @@ class TestByHarmCategory:
         report = TestRunReport(
             results=[
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="a",
                     harm_category=HarmCategory.DATA_EXFILTRATION,
                 ),
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="b",
                     harm_category=None,
                 ),
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="c",
                     harm_category="team_specific",
@@ -138,8 +129,8 @@ class TestPopulationSummary:
     def test_all_safe(self) -> None:
         report = TestRunReport(
             results=[
-                Result(safe=True, status=SafetyStatus.SAFE, summary="ok"),
-                Result(safe=True, status=SafetyStatus.SAFE, summary="ok2"),
+                Result(status=SafetyStatus.SAFE, summary="ok"),
+                Result(status=SafetyStatus.SAFE, summary="ok2"),
             ],
         )
 
@@ -153,9 +144,9 @@ class TestPopulationSummary:
     def test_mixed_results(self) -> None:
         report = TestRunReport(
             results=[
-                Result(safe=True, status=SafetyStatus.SAFE, summary="ok"),
-                Result(safe=False, status=SafetyStatus.UNSAFE, summary="bad"),
-                Result(safe=False, status=SafetyStatus.UNDETERMINED, summary="?"),
+                Result(status=SafetyStatus.SAFE, summary="ok"),
+                Result(status=SafetyStatus.UNSAFE, summary="bad"),
+                Result(status=SafetyStatus.UNDETERMINED, summary="?"),
             ],
         )
 
@@ -177,9 +168,9 @@ class TestPopulationSummary:
     def test_error_excluded_from_attack_success_rate(self) -> None:
         report = TestRunReport(
             results=[
-                Result(safe=True, status=SafetyStatus.SAFE, summary="ok"),
-                Result(safe=False, status=SafetyStatus.UNSAFE, summary="bad"),
-                Result(safe=False, status=SafetyStatus.ERROR, summary="infra"),
+                Result(status=SafetyStatus.SAFE, summary="ok"),
+                Result(status=SafetyStatus.UNSAFE, summary="bad"),
+                Result(status=SafetyStatus.ERROR, summary="infra"),
             ],
         )
 
@@ -192,8 +183,8 @@ class TestPopulationSummary:
     def test_all_errors(self) -> None:
         report = TestRunReport(
             results=[
-                Result(safe=False, status=SafetyStatus.ERROR, summary="err1"),
-                Result(safe=False, status=SafetyStatus.ERROR, summary="err2"),
+                Result(status=SafetyStatus.ERROR, summary="err1"),
+                Result(status=SafetyStatus.ERROR, summary="err2"),
             ],
         )
 
@@ -207,19 +198,16 @@ class TestPopulationSummary:
         report = TestRunReport(
             results=[
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="ok",
                     harm_category=HarmCategory.DATA_EXFILTRATION,
                 ),
                 Result(
-                    safe=False,
                     status=SafetyStatus.UNSAFE,
                     summary="bad",
                     harm_category=HarmCategory.JAILBREAK,
                 ),
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="ok2",
                     harm_category=HarmCategory.DATA_EXFILTRATION,
@@ -236,13 +224,11 @@ class TestPopulationSummary:
         report = TestRunReport(
             results=[
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="ok",
                     harm_category="custom",
                 ),
                 Result(
-                    safe=False,
                     status=SafetyStatus.UNSAFE,
                     summary="bad",
                     harm_category="other",
@@ -258,7 +244,6 @@ class TestPopulationSummary:
         report = TestRunReport(
             results=[
                 Result(
-                    safe=True,
                     status=SafetyStatus.SAFE,
                     summary="ok",
                     harm_category=HarmCategory.DATA_EXFILTRATION,


### PR DESCRIPTION
## What

`Result.safe` is now a computed `@property` (`status is SafetyStatus.SAFE`) instead of a stored dataclass field, so it can never drift out of sync with `status`.

Since the invariant `safe == (status is SafetyStatus.SAFE)` already held everywhere, this also removes the now-redundant `safe` value from the resolver plumbing:

- `resolve_as_attack` / `resolve_as_probe` now return `SafetyStatus` directly instead of a `(safe, status)` tuple.
- `XPIAExecution._adjust_for_observability` takes/returns only `SafetyStatus`.
- All `Result(...)` constructions drop the `safe=` argument.

## Notes

- `result.safe`, `bool(result)`, and `repr(result)` (still shows `safe=...`) behave exactly as before.
- Updated the affected doc examples (`extending-rampart.md`, `testing.md`, `pytest-integration.md`).

## Testing

- `ruff check rampart tests` — all checks passed
- `pytest tests/unit` — 616 passed