### PR TITLE
[FIX]: Enforce PromptTemplate construction invariants

### DIFF
--- a/rampart/common/templates.py
+++ b/rampart/common/templates.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from collections.abc import Hashable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Annotated, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Annotated, TypeAlias, TypeVar, final
 
 import yaml
 from jinja2 import (
@@ -98,14 +98,30 @@ class TemplateParameterError(ValueError):
         super().__init__(msg)
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
+@final
+@dataclass(
+    frozen=True,
+    kw_only=True,
+    slots=True,
+    init=False,
+    eq=False,
+)
 class PromptTemplate:
     """Compiled prompt template with metadata and an explicit render contract."""
 
     name: str
     description: str | None
     parameter_keys: tuple[str, ...]
-    _template: Template = field(repr=False, compare=False)
+    _template: Template = field(repr=False)
+
+    def __init__(self) -> None:
+        """Reject construction that bypasses template validation.
+
+        Raises:
+            TypeError: Always. Use :meth:`from_yaml` to construct an instance.
+        """
+        msg = "Use PromptTemplate.from_yaml()"
+        raise TypeError(msg)
 
     @classmethod
     def from_yaml(cls, path: Path) -> Self:
@@ -127,12 +143,31 @@ class PromptTemplate:
                 a valid prompt template.
         """
         definition = _load_yaml_definition(path)
-        return cls(
-            name=definition.name,
-            description=definition.description,
-            parameter_keys=tuple(definition.parameters),
-            _template=_compile_template(definition, path=path),
+        return cls._from_validated_definition(definition=definition, path=path)
+
+    @classmethod
+    def _from_validated_definition(
+        cls,
+        *,
+        definition: _PromptTemplateYaml,
+        path: Path,
+    ) -> Self:
+        compiled = _compile_template(definition, path=path)
+
+        instance = object.__new__(cls)
+        object.__setattr__(instance, "name", definition.name)  # ruff:ignore[unnecessary-dunder-call]
+        object.__setattr__(  # ruff:ignore[unnecessary-dunder-call]
+            instance,
+            "description",
+            definition.description,
         )
+        object.__setattr__(  # ruff:ignore[unnecessary-dunder-call]
+            instance,
+            "parameter_keys",
+            tuple(definition.parameters),
+        )
+        object.__setattr__(instance, "_template", compiled)  # ruff:ignore[unnecessary-dunder-call]
+        return instance
 
     def render(self, **kwargs: object) -> str:
         """Render with exactly the declared keyword arguments.

--- a/tests/unit/common/test_templates.py
+++ b/tests/unit/common/test_templates.py
@@ -3,16 +3,20 @@
 
 from pathlib import Path
 from textwrap import dedent
+from typing import TYPE_CHECKING, cast
 
 import pytest
 import yaml
-from jinja2 import TemplateError
+from jinja2 import Template, TemplateError
 
 from rampart.common.templates import (
     PromptTemplate,
     PromptTemplateDefinitionError,
     TemplateParameterError,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _write_yaml(tmp_path: Path, data: object) -> Path:
@@ -35,6 +39,32 @@ def _write_template(tmp_path: Path, **overrides: object) -> Path:
     }
     definition.update(overrides)
     return _write_yaml(tmp_path, definition)
+
+
+class TestPromptTemplateInitialization:
+    def test_rejects_direct_construction(self) -> None:
+        with pytest.raises(TypeError, match=r"Use PromptTemplate\.from_yaml\(\)"):
+            PromptTemplate()
+
+    def test_rejects_generated_constructor_arguments(self) -> None:
+        constructor = cast("Callable[..., PromptTemplate]", PromptTemplate)
+
+        with pytest.raises(TypeError):
+            constructor(
+                name="x",
+                description=None,
+                parameter_keys=("declared",),
+                _template=Template("{{ actual }}"),
+            )
+
+    def test_uses_identity_equality_and_hashing(self, tmp_path: Path) -> None:
+        path = _write_template(tmp_path)
+
+        first = PromptTemplate.from_yaml(path)
+        second = PromptTemplate.from_yaml(path)
+
+        assert first != second
+        assert len({first, second}) == 2
 
 
 class TestPromptTemplateFromYaml:


### PR DESCRIPTION
## Description

Fixes construction and equality invariants for `PromptTemplate` introduced in #120.

The dataclass-generated initializer exposed every field, including `_template`. A leading underscore is only a Python naming convention, so a caller could combine declared parameter metadata with an unrelated Jinja template and bypass `PromptTemplate.from_yaml()` validation:

```python
PromptTemplate(
    name="x",
    description=None,
    parameter_keys=("declared",),
    _template=Template("{{ actual }}"),
).render(declared="provided")
```

This renders an empty string: argument validation succeeds against `parameter_keys`, while the injected template references a different variable and was compiled outside RAMPART's `StrictUndefined` environment.

This PR:

- disables the generated dataclass initializer and explicitly rejects direct construction, including the otherwise-valid empty `PromptTemplate()` call left available by `init=False` alone;
- creates instances only from a schema-validated YAML definition;
- compiles the Jinja template inside the validated-definition factory so the declared parameters and compiled behavior cannot drift independently;
- uses `object.__new__()` and `object.__setattr__()` for the narrow initialization phase required by a frozen, slotted dataclass;
- disables generated structural equality, which previously treated templates with identical metadata but different bodies as equal because `_template` was excluded from comparison, while preserving identity-based hashing; and
- marks `PromptTemplate` as final for static type checkers and IDEs.

`PromptTemplate.from_yaml(path)` remains the supported construction API and retains its `Self` return type. Separate instances now use identity equality:

```python
first = PromptTemplate.from_yaml(path)
second = PromptTemplate.from_yaml(path)

assert first is not second
assert first != second
assert len({first, second}) == 2
```

## Breaking changes

Direct `PromptTemplate(...)` construction is now rejected. Use `PromptTemplate.from_yaml(path)` instead. Equality between separate instances is now identity-based rather than metadata-based. Existing RAMPART production call sites already construct templates through `from_yaml()`.

## Checklist

- [X] `pre-commit run --all-files` passes
- [X] Tests added or updated for changes: direct construction, the former generated-constructor arguments, identity equality, and hashability
- [X] Documentation updated: factory-only construction and migration are documented above and in the API docstrings