### PR TITLE
[FIX]: Restrict PromptTemplate construction to YAML paths

### DIFF
--- a/rampart/common/templates.py
+++ b/rampart/common/templates.py
@@ -20,8 +20,7 @@ render call before evaluating Jinja markup.
 from __future__ import annotations
 
 from collections.abc import Hashable
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Annotated, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Annotated, TypeAlias, TypeVar, final
 
 import yaml
 from jinja2 import (
@@ -43,7 +42,6 @@ __all__ = [
 if TYPE_CHECKING:
     from collections.abc import Collection
     from pathlib import Path
-    from typing import Self
 
 
 _JINJA_ENVIRONMENT = Environment(
@@ -98,17 +96,13 @@ class TemplateParameterError(ValueError):
         super().__init__(msg)
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
+@final
 class PromptTemplate:
-    """Compiled prompt template with metadata and an explicit render contract."""
+    """Compiled YAML prompt template with an explicit render contract."""
 
-    name: str
-    description: str | None
-    parameter_keys: tuple[str, ...]
-    _template: Template = field(repr=False, compare=False)
+    __slots__ = ("_description", "_name", "_parameter_keys", "_template")
 
-    @classmethod
-    def from_yaml(cls, path: Path) -> Self:
+    def __init__(self, yaml_path: Path) -> None:
         """Load and compile a prompt template from YAML.
 
         ``name``, ``parameters``, and ``value`` are required. ``description``
@@ -116,23 +110,35 @@ class PromptTemplate:
         referenced by the Jinja template.
 
         Args:
-            path: Path to the YAML template file.
-
-        Returns:
-            Self: A structured, compiled prompt template.
+            yaml_path: Path to the YAML template file.
 
         Raises:
-            FileNotFoundError: If *path* does not exist.
+            FileNotFoundError: If *yaml_path* does not exist.
             PromptTemplateDefinitionError: If the file contents do not define
                 a valid prompt template.
         """
-        definition = _load_yaml_definition(path)
-        return cls(
-            name=definition.name,
-            description=definition.description,
-            parameter_keys=tuple(definition.parameters),
-            _template=_compile_template(definition, path=path),
-        )
+        definition = _load_yaml_definition(yaml_path)
+        template = _compile_template(definition, path=yaml_path)
+
+        self._name = definition.name
+        self._description = definition.description
+        self._parameter_keys = tuple(definition.parameters)
+        self._template = template
+
+    @property
+    def name(self) -> str:
+        """Human-readable template name."""
+        return self._name
+
+    @property
+    def description(self) -> str | None:
+        """Human-readable template purpose, when provided."""
+        return self._description
+
+    @property
+    def parameter_keys(self) -> tuple[str, ...]:
+        """Keyword names accepted by :meth:`render`."""
+        return self._parameter_keys
 
     def render(self, **kwargs: object) -> str:
         """Render with exactly the declared keyword arguments.
@@ -158,6 +164,14 @@ class PromptTemplate:
                 unexpected=unexpected,
             )
         return self._template.render(**kwargs)
+
+    def __repr__(self) -> str:
+        """Return a representation containing the public template metadata."""
+        return (
+            f"PromptTemplate(name={self.name!r}, "
+            f"description={self.description!r}, "
+            f"parameter_keys={self.parameter_keys!r})"
+        )
 
 
 _UniqueItemT = TypeVar("_UniqueItemT", bound=Hashable)

--- a/rampart/common/templates.py
+++ b/rampart/common/templates.py
@@ -102,7 +102,7 @@ class PromptTemplate:
 
     __slots__ = ("_description", "_name", "_parameter_keys", "_template")
 
-    def __init__(self, yaml_path: Path) -> None:
+    def __init__(self, *, path: Path) -> None:
         """Load and compile a prompt template from YAML.
 
         ``name``, ``parameters``, and ``value`` are required. ``description``
@@ -110,15 +110,15 @@ class PromptTemplate:
         referenced by the Jinja template.
 
         Args:
-            yaml_path: Path to the YAML template file.
+            path: Path to the YAML template file.
 
         Raises:
-            FileNotFoundError: If *yaml_path* does not exist.
+            FileNotFoundError: If *path* does not exist.
             PromptTemplateDefinitionError: If the file contents do not define
                 a valid prompt template.
         """
-        definition = _load_yaml_definition(yaml_path)
-        template = _compile_template(definition, path=yaml_path)
+        definition = _load_yaml_definition(path)
+        template = _compile_template(definition, path=path)
 
         self._name = definition.name
         self._description = definition.description

--- a/rampart/drivers/llm.py
+++ b/rampart/drivers/llm.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
-_SYSTEM_PROMPT_TEMPLATE = PromptTemplate.from_yaml(
+_SYSTEM_PROMPT_TEMPLATE = PromptTemplate(
     _PROMPTS_DIR / "llm_driver_system_prompt.yaml",
 )
 

--- a/rampart/drivers/llm.py
+++ b/rampart/drivers/llm.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
 _SYSTEM_PROMPT_TEMPLATE = PromptTemplate(
-    _PROMPTS_DIR / "llm_driver_system_prompt.yaml",
+    path=_PROMPTS_DIR / "llm_driver_system_prompt.yaml",
 )
 
 

--- a/rampart/evaluators/llm_judge.py
+++ b/rampart/evaluators/llm_judge.py
@@ -60,7 +60,7 @@ class TranscriptScope(Enum):
 
 
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
-_SYSTEM_PROMPT_TEMPLATE = PromptTemplate(_PROMPTS_DIR / "llm_judge.yaml")
+_SYSTEM_PROMPT_TEMPLATE = PromptTemplate(path=_PROMPTS_DIR / "llm_judge.yaml")
 
 _ALLOWED_OUTCOMES: frozenset[str] = frozenset(
     {"detected", "not_detected", "undetermined"},

--- a/rampart/evaluators/llm_judge.py
+++ b/rampart/evaluators/llm_judge.py
@@ -60,7 +60,7 @@ class TranscriptScope(Enum):
 
 
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
-_SYSTEM_PROMPT_TEMPLATE = PromptTemplate.from_yaml(_PROMPTS_DIR / "llm_judge.yaml")
+_SYSTEM_PROMPT_TEMPLATE = PromptTemplate(_PROMPTS_DIR / "llm_judge.yaml")
 
 _ALLOWED_OUTCOMES: frozenset[str] = frozenset(
     {"detected", "not_detected", "undetermined"},

--- a/tests/unit/common/test_templates.py
+++ b/tests/unit/common/test_templates.py
@@ -3,16 +3,20 @@
 
 from pathlib import Path
 from textwrap import dedent
+from typing import TYPE_CHECKING, cast
 
 import pytest
 import yaml
-from jinja2 import TemplateError
+from jinja2 import Template, TemplateError
 
 from rampart.common.templates import (
     PromptTemplate,
     PromptTemplateDefinitionError,
     TemplateParameterError,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _write_yaml(tmp_path: Path, data: object) -> Path:
@@ -37,7 +41,57 @@ def _write_template(tmp_path: Path, **overrides: object) -> Path:
     return _write_yaml(tmp_path, definition)
 
 
-class TestPromptTemplateFromYaml:
+class TestPromptTemplateInitialization:
+    def test_rejects_component_construction(self) -> None:
+        constructor = cast("Callable[..., PromptTemplate]", PromptTemplate)
+
+        with pytest.raises(TypeError):
+            constructor(
+                name="Greeting",
+                description=None,
+                parameter_keys=("subject",),
+                _template=Template("Hello, {{ subject }}!"),
+            )
+
+    @pytest.mark.parametrize(
+        "attribute",
+        ["name", "description", "parameter_keys"],
+    )
+    def test_metadata_properties_are_read_only(
+        self,
+        tmp_path: Path,
+        attribute: str,
+    ) -> None:
+        template = PromptTemplate(_write_template(tmp_path))
+
+        with pytest.raises(AttributeError):
+            setattr(template, attribute, "changed")
+
+    def test_prevents_unknown_attributes(self, tmp_path: Path) -> None:
+        template = PromptTemplate(_write_template(tmp_path))
+
+        assert not hasattr(template, "__dict__")
+
+    def test_uses_identity_equality_and_hashing(self, tmp_path: Path) -> None:
+        path = _write_template(tmp_path)
+
+        first = PromptTemplate(path)
+        second = PromptTemplate(path)
+
+        assert first != second
+        assert len({first, second}) == 2
+
+    def test_representation_contains_only_public_metadata(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        template = PromptTemplate(_write_template(tmp_path))
+
+        assert repr(template) == (
+            "PromptTemplate(name='Greeting', description=None, "
+            "parameter_keys=('subject',))"
+        )
+
     def test_loads_raw_yaml_block_scalars(self, tmp_path: Path) -> None:
         path = _write_raw_yaml(
             tmp_path,
@@ -54,7 +108,7 @@ class TestPromptTemplateFromYaml:
             ),
         )
 
-        template = PromptTemplate.from_yaml(path)
+        template = PromptTemplate(path)
 
         assert template.name == "Greeting"
         assert template.description == "Greets a subject across\nmultiple lines.\n"
@@ -74,7 +128,7 @@ class TestPromptTemplateFromYaml:
         )
 
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
-            PromptTemplate.from_yaml(path)
+            PromptTemplate(path)
 
         assert isinstance(exc_info.value.__cause__, yaml.YAMLError)
 
@@ -93,7 +147,7 @@ class TestPromptTemplateFromYaml:
         path = _write_raw_yaml(tmp_path, content)
 
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
-            PromptTemplate.from_yaml(path)
+            PromptTemplate(path)
 
         assert exc_info.value.path == path
         assert exc_info.value.__cause__ is not None
@@ -101,7 +155,7 @@ class TestPromptTemplateFromYaml:
     def test_loads_metadata_and_renders_successfully(self, tmp_path: Path) -> None:
         path = _write_template(tmp_path, description="Greets a subject.")
 
-        template = PromptTemplate.from_yaml(path)
+        template = PromptTemplate(path)
 
         assert isinstance(template, PromptTemplate)
         assert template.name == "Greeting"
@@ -110,12 +164,12 @@ class TestPromptTemplateFromYaml:
         assert template.render(subject="Ada") == "Hello, Ada!"
 
     def test_optional_description_defaults_to_none(self, tmp_path: Path) -> None:
-        template = PromptTemplate.from_yaml(_write_template(tmp_path))
+        template = PromptTemplate(_write_template(tmp_path))
 
         assert template.description is None
 
     def test_rejects_missing_parameter(self, tmp_path: Path) -> None:
-        template = PromptTemplate.from_yaml(_write_template(tmp_path))
+        template = PromptTemplate(_write_template(tmp_path))
 
         with pytest.raises(TemplateParameterError) as exc_info:
             template.render()
@@ -125,7 +179,7 @@ class TestPromptTemplateFromYaml:
         assert exc_info.value.unexpected == ()
 
     def test_rejects_unexpected_parameter(self, tmp_path: Path) -> None:
-        template = PromptTemplate.from_yaml(_write_template(tmp_path))
+        template = PromptTemplate(_write_template(tmp_path))
 
         with pytest.raises(TemplateParameterError) as exc_info:
             template.render(subject="Ada", subejct="typo")
@@ -143,13 +197,13 @@ class TestPromptTemplateFromYaml:
             PromptTemplateDefinitionError,
             match=r"missing=\('subject',\), unused=\('declared_but_unused',\)",
         ):
-            PromptTemplate.from_yaml(path)
+            PromptTemplate(path)
 
     def test_wraps_invalid_jinja_syntax(self, tmp_path: Path) -> None:
         path = _write_template(tmp_path, value="{{ subject")
 
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
-            PromptTemplate.from_yaml(path)
+            PromptTemplate(path)
 
         assert isinstance(exc_info.value.__cause__, TemplateError)
 
@@ -158,7 +212,7 @@ class TestPromptTemplateFromYaml:
         path.write_bytes(b"\xff")
 
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
-            PromptTemplate.from_yaml(path)
+            PromptTemplate(path)
 
         assert isinstance(exc_info.value.__cause__, UnicodeDecodeError)
 
@@ -166,7 +220,7 @@ class TestPromptTemplateFromYaml:
         path = tmp_path / "missing.yaml"
 
         with pytest.raises(FileNotFoundError):
-            PromptTemplate.from_yaml(path)
+            PromptTemplate(path)
 
     @pytest.mark.parametrize(
         ("definition", "error_fragment"),
@@ -211,7 +265,7 @@ class TestPromptTemplateFromYaml:
         path = _write_yaml(tmp_path, definition)
 
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
-            PromptTemplate.from_yaml(path)
+            PromptTemplate(path)
 
         assert exc_info.value.path == path
         assert error_fragment in str(exc_info.value)

--- a/tests/unit/common/test_templates.py
+++ b/tests/unit/common/test_templates.py
@@ -42,6 +42,12 @@ def _write_template(tmp_path: Path, **overrides: object) -> Path:
 
 
 class TestPromptTemplateInitialization:
+    def test_requires_path_keyword(self, tmp_path: Path) -> None:
+        constructor = cast("Callable[..., PromptTemplate]", PromptTemplate)
+
+        with pytest.raises(TypeError):
+            constructor(_write_template(tmp_path))
+
     def test_rejects_component_construction(self) -> None:
         constructor = cast("Callable[..., PromptTemplate]", PromptTemplate)
 
@@ -62,21 +68,21 @@ class TestPromptTemplateInitialization:
         tmp_path: Path,
         attribute: str,
     ) -> None:
-        template = PromptTemplate(_write_template(tmp_path))
+        template = PromptTemplate(path=_write_template(tmp_path))
 
         with pytest.raises(AttributeError):
             setattr(template, attribute, "changed")
 
     def test_prevents_unknown_attributes(self, tmp_path: Path) -> None:
-        template = PromptTemplate(_write_template(tmp_path))
+        template = PromptTemplate(path=_write_template(tmp_path))
 
         assert not hasattr(template, "__dict__")
 
     def test_uses_identity_equality_and_hashing(self, tmp_path: Path) -> None:
         path = _write_template(tmp_path)
 
-        first = PromptTemplate(path)
-        second = PromptTemplate(path)
+        first = PromptTemplate(path=path)
+        second = PromptTemplate(path=path)
 
         assert first != second
         assert len({first, second}) == 2
@@ -85,7 +91,7 @@ class TestPromptTemplateInitialization:
         self,
         tmp_path: Path,
     ) -> None:
-        template = PromptTemplate(_write_template(tmp_path))
+        template = PromptTemplate(path=_write_template(tmp_path))
 
         assert repr(template) == (
             "PromptTemplate(name='Greeting', description=None, "
@@ -108,7 +114,7 @@ class TestPromptTemplateInitialization:
             ),
         )
 
-        template = PromptTemplate(path)
+        template = PromptTemplate(path=path)
 
         assert template.name == "Greeting"
         assert template.description == "Greets a subject across\nmultiple lines.\n"
@@ -128,7 +134,7 @@ class TestPromptTemplateInitialization:
         )
 
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
-            PromptTemplate(path)
+            PromptTemplate(path=path)
 
         assert isinstance(exc_info.value.__cause__, yaml.YAMLError)
 
@@ -147,7 +153,7 @@ class TestPromptTemplateInitialization:
         path = _write_raw_yaml(tmp_path, content)
 
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
-            PromptTemplate(path)
+            PromptTemplate(path=path)
 
         assert exc_info.value.path == path
         assert exc_info.value.__cause__ is not None
@@ -155,7 +161,7 @@ class TestPromptTemplateInitialization:
     def test_loads_metadata_and_renders_successfully(self, tmp_path: Path) -> None:
         path = _write_template(tmp_path, description="Greets a subject.")
 
-        template = PromptTemplate(path)
+        template = PromptTemplate(path=path)
 
         assert isinstance(template, PromptTemplate)
         assert template.name == "Greeting"
@@ -164,12 +170,12 @@ class TestPromptTemplateInitialization:
         assert template.render(subject="Ada") == "Hello, Ada!"
 
     def test_optional_description_defaults_to_none(self, tmp_path: Path) -> None:
-        template = PromptTemplate(_write_template(tmp_path))
+        template = PromptTemplate(path=_write_template(tmp_path))
 
         assert template.description is None
 
     def test_rejects_missing_parameter(self, tmp_path: Path) -> None:
-        template = PromptTemplate(_write_template(tmp_path))
+        template = PromptTemplate(path=_write_template(tmp_path))
 
         with pytest.raises(TemplateParameterError) as exc_info:
             template.render()
@@ -179,7 +185,7 @@ class TestPromptTemplateInitialization:
         assert exc_info.value.unexpected == ()
 
     def test_rejects_unexpected_parameter(self, tmp_path: Path) -> None:
-        template = PromptTemplate(_write_template(tmp_path))
+        template = PromptTemplate(path=_write_template(tmp_path))
 
         with pytest.raises(TemplateParameterError) as exc_info:
             template.render(subject="Ada", subejct="typo")
@@ -197,13 +203,13 @@ class TestPromptTemplateInitialization:
             PromptTemplateDefinitionError,
             match=r"missing=\('subject',\), unused=\('declared_but_unused',\)",
         ):
-            PromptTemplate(path)
+            PromptTemplate(path=path)
 
     def test_wraps_invalid_jinja_syntax(self, tmp_path: Path) -> None:
         path = _write_template(tmp_path, value="{{ subject")
 
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
-            PromptTemplate(path)
+            PromptTemplate(path=path)
 
         assert isinstance(exc_info.value.__cause__, TemplateError)
 
@@ -212,7 +218,7 @@ class TestPromptTemplateInitialization:
         path.write_bytes(b"\xff")
 
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
-            PromptTemplate(path)
+            PromptTemplate(path=path)
 
         assert isinstance(exc_info.value.__cause__, UnicodeDecodeError)
 
@@ -220,7 +226,7 @@ class TestPromptTemplateInitialization:
         path = tmp_path / "missing.yaml"
 
         with pytest.raises(FileNotFoundError):
-            PromptTemplate(path)
+            PromptTemplate(path=path)
 
     @pytest.mark.parametrize(
         ("definition", "error_fragment"),
@@ -265,7 +271,7 @@ class TestPromptTemplateInitialization:
         path = _write_yaml(tmp_path, definition)
 
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
-            PromptTemplate(path)
+            PromptTemplate(path=path)
 
         assert exc_info.value.path == path
         assert error_fragment in str(exc_info.value)


### PR DESCRIPTION
## Description

This takes a simpler route than #132: instead of keeping the dataclass and adding a guarded factory path, `PromptTemplate` is now a plain final class whose only constructor requires a YAML `Path` through the named `path` argument.

Construction loads the file, validates the schema and parameter contract, and compiles Jinja before assigning instance state. `name`, `description`, and `parameter_keys` remain public as read-only properties. The compiled template stays private, and `__slots__` prevents accidental attributes. Identity equality and hashing replace the dataclass's misleading structural equality.

The LLM driver and judge now use `PromptTemplate(path=path)`. Tests cover the keyword-only path contract, component injection rejection, read-only metadata, slots, identity semantics, representation, and the existing YAML and render failure cases.

The read-only contract applies to the public API. Private slots remain conventional Python internals; this intentionally avoids adding custom runtime freezing machinery.

## Breaking changes

`PromptTemplate.from_yaml(path)` is replaced with `PromptTemplate(path=path)`. This API was introduced after v0.1.0 and has not shipped in a release. Direct component-wise dataclass construction is no longer accepted.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Tests added or updated for constructor invariants, the keyword-only path, read-only properties, identity semantics, and existing template behavior
- [x] Documentation updated in the API docstrings