### PR TITLE
[REFACTOR]: Decouple PromptTemplate creation from YAML

### DIFF
--- a/rampart/common/templates.py
+++ b/rampart/common/templates.py
@@ -1,27 +1,18 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-"""YAML prompt-template loader shared by drivers and evaluators.
+"""Source-neutral prompt-template definition, compilation, and YAML loading.
 
-RAMPART keeps prompt text in YAML files under per-package ``prompts/``
-directories. Each file uses this schema:
-
-- ``name`` (required): Human-readable template name.
-- ``parameters`` (required): Exact keyword names accepted by ``render()``.
-- ``value`` (required): Jinja2 template source.
-- ``description`` (optional): Human-readable purpose; defaults to ``None``.
-
-Unknown keys and type coercion are rejected. Parameter names must be unique.
-The loader maps ``parameters`` to :attr:`PromptTemplate.parameter_keys`,
-compiles ``value``, and returns a structured template that validates every
-render call before evaluating Jinja markup.
+``PromptTemplate`` accepts only a validated ``PromptTemplateDefinition`` and
+compiles its Jinja source internally. ``PromptTemplate.from_yaml`` is the
+filesystem and YAML adapter used by RAMPART's built-in drivers and evaluators.
+Every render call must provide exactly the definition's declared parameters.
 """
 
 from __future__ import annotations
 
 from collections.abc import Hashable
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Annotated, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Annotated, TypeAlias, TypeVar, final
 
 import yaml
 from jinja2 import (
@@ -29,13 +20,22 @@ from jinja2 import (
     StrictUndefined,
     Template,
     TemplateError,
+    TemplateSyntaxError,
     meta,
     select_autoescape,
 )
-from pydantic import AfterValidator, BaseModel, ConfigDict, ValidationError
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    ValidationError,
+)
 
 __all__ = [
     "PromptTemplate",
+    "PromptTemplateDefinition",
     "PromptTemplateDefinitionError",
     "TemplateParameterError",
 ]
@@ -53,18 +53,58 @@ _JINJA_ENVIRONMENT = Environment(
 
 
 class PromptTemplateDefinitionError(ValueError):
-    """Raised when file contents do not define a valid prompt template."""
+    """Raised when data does not define a valid prompt template."""
 
-    def __init__(self, *, path: Path, details: str) -> None:
+    def __init__(
+        self,
+        *,
+        details: str,
+        template_name: str | None = None,
+        template_line: int | None = None,
+        path: Path | None = None,
+    ) -> None:
         """Initialize an invalid-definition error.
 
         Args:
-            path: Path to the invalid YAML template.
             details: Human-readable failure details.
+            template_name: Human-readable template name, when available.
+            template_line: Line within the template value, when available.
+            path: Path from which the definition was loaded, when applicable.
         """
         self.path = path
-        msg = f"Prompt template {path} is invalid:\n{details}"
-        super().__init__(msg)
+        self.details = details
+        self.template_name = template_name
+        self.template_line = template_line
+        super().__init__(self._format_message())
+
+    def add_path(self, path: Path) -> None:
+        """Add adapter context while preserving this exception instance.
+
+        Args:
+            path: Path from which the invalid definition was loaded.
+        """
+        self.path = path
+        self.args = (self._format_message(),)
+
+    def _format_message(self) -> str:
+        """Format the error from its structured fields.
+
+        Returns:
+            str: Human-readable error message.
+        """
+        if self.template_name is not None:
+            subject = f"Prompt template {self.template_name!r}"
+            if self.path is not None:
+                subject += f" loaded from {self.path}"
+        elif self.path is not None:
+            subject = f"Prompt template {self.path}"
+        else:
+            subject = "Prompt template"
+
+        location = ""
+        if self.template_line is not None:
+            location = f" (template value line {self.template_line})"
+        return f"{subject} is invalid{location}:\n{self.details}"
 
 
 class TemplateParameterError(ValueError):
@@ -98,14 +138,24 @@ class TemplateParameterError(ValueError):
         super().__init__(msg)
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
+@final
 class PromptTemplate:
     """Compiled prompt template with metadata and an explicit render contract."""
 
-    name: str
-    description: str | None
-    parameter_keys: tuple[str, ...]
-    _template: Template = field(repr=False, compare=False)
+    __slots__ = ("_description", "_name", "_parameter_keys", "_template")
+
+    def __init__(self, *, definition: PromptTemplateDefinition) -> None:
+        """Compile a validated prompt template definition.
+
+        Args:
+            definition: Source-neutral prompt template definition.
+        """
+        template = _compile_template(definition)
+
+        self._name = definition.name
+        self._description = definition.description
+        self._parameter_keys = definition.parameters
+        self._template = template
 
     @classmethod
     def from_yaml(cls, path: Path) -> Self:
@@ -127,12 +177,26 @@ class PromptTemplate:
                 a valid prompt template.
         """
         definition = _load_yaml_definition(path)
-        return cls(
-            name=definition.name,
-            description=definition.description,
-            parameter_keys=tuple(definition.parameters),
-            _template=_compile_template(definition, path=path),
-        )
+        try:
+            return cls(definition=definition)
+        except PromptTemplateDefinitionError as exc:
+            exc.add_path(path)
+            raise
+
+    @property
+    def name(self) -> str:
+        """Human-readable template name."""
+        return self._name
+
+    @property
+    def description(self) -> str | None:
+        """Human-readable template purpose, when provided."""
+        return self._description
+
+    @property
+    def parameter_keys(self) -> tuple[str, ...]:
+        """Keyword names accepted by :meth:`render`."""
+        return self._parameter_keys
 
     def render(self, **kwargs: object) -> str:
         """Render with exactly the declared keyword arguments.
@@ -159,18 +223,42 @@ class PromptTemplate:
             )
         return self._template.render(**kwargs)
 
+    def __repr__(self) -> str:
+        """Return a representation containing only public metadata."""
+        return (
+            f"PromptTemplate(name={self.name!r}, "
+            f"description={self.description!r}, "
+            f"parameter_keys={self.parameter_keys!r})"
+        )
+
 
 _UniqueItemT = TypeVar("_UniqueItemT", bound=Hashable)
 
 
-def _require_unique(values: list[_UniqueItemT]) -> list[_UniqueItemT]:
+def _convert_list_to_tuple(values: object) -> object:
+    """Convert a serialized list to its immutable domain representation.
+
+    Args:
+        values: Raw value to normalize.
+
+    Returns:
+        object: A tuple for list input; otherwise the original value.
+    """
+    if isinstance(values, list):
+        return tuple(values)
+    return values
+
+
+def _require_unique(
+    values: tuple[_UniqueItemT, ...],
+) -> tuple[_UniqueItemT, ...]:
     """Reject duplicate values.
 
     Args:
         values: Values to validate.
 
     Returns:
-        list[_UniqueItemT]: The validated values in their original order.
+        tuple[_UniqueItemT, ...]: The validated values in their original order.
 
     Raises:
         ValueError: If any value appears more than once.
@@ -181,14 +269,22 @@ def _require_unique(values: list[_UniqueItemT]) -> list[_UniqueItemT]:
     return values
 
 
-_UniqueList: TypeAlias = Annotated[
-    list[_UniqueItemT],
+_UniqueTuple: TypeAlias = Annotated[
+    tuple[_UniqueItemT, ...],
+    BeforeValidator(_convert_list_to_tuple),
     AfterValidator(_require_unique),
 ]
 
 
-class _PromptTemplateYaml(BaseModel):
-    """Strict schema for the serialized YAML representation."""
+class PromptTemplateDefinition(BaseModel):
+    """Strict, source-neutral definition of a prompt template.
+
+    Attributes:
+        name: Human-readable template name.
+        parameters: Ordered, unique keyword names accepted by ``render()``.
+        value: Jinja template source, omitted from the representation.
+        description: Human-readable purpose, when provided.
+    """
 
     model_config = ConfigDict(
         extra="forbid",
@@ -198,19 +294,19 @@ class _PromptTemplateYaml(BaseModel):
     )
 
     name: str
-    parameters: _UniqueList[str]
-    value: str
+    parameters: _UniqueTuple[str]
+    value: str = Field(repr=False)
     description: str | None = None
 
 
-def _load_yaml_definition(path: Path) -> _PromptTemplateYaml:
+def _load_yaml_definition(path: Path) -> PromptTemplateDefinition:
     """Load and validate the serialized YAML representation.
 
     Args:
         path: Path to the YAML template file.
 
     Returns:
-        _PromptTemplateYaml: The validated YAML definition.
+        PromptTemplateDefinition: The validated template definition.
 
     Raises:
         FileNotFoundError: If *path* does not exist.
@@ -224,21 +320,18 @@ def _load_yaml_definition(path: Path) -> _PromptTemplateYaml:
         raise PromptTemplateDefinitionError(path=path, details=str(exc)) from exc
 
     try:
-        return _PromptTemplateYaml.model_validate(data)
+        return PromptTemplateDefinition.model_validate(data)
     except ValidationError as exc:
         raise PromptTemplateDefinitionError(path=path, details=str(exc)) from exc
 
 
 def _compile_template(
-    definition: _PromptTemplateYaml,
-    *,
-    path: Path,
+    definition: PromptTemplateDefinition,
 ) -> Template:
     """Compile a validated definition after checking its parameter contract.
 
     Args:
-        definition: Validated YAML template definition.
-        path: Source path used in Jinja diagnostics.
+        definition: Validated source-neutral template definition.
 
     Returns:
         Template: The compiled Jinja template.
@@ -248,26 +341,43 @@ def _compile_template(
             declared parameters do not match its variables.
     """
     try:
-        parsed = _JINJA_ENVIRONMENT.parse(
-            definition.value,
-            name=definition.name,
-            filename=str(path),
-        )
+        parsed = _JINJA_ENVIRONMENT.parse(definition.value)
         referenced_keys = meta.find_undeclared_variables(parsed)
+    except TemplateSyntaxError as exc:
+        raise PromptTemplateDefinitionError(
+            details=exc.message or str(exc),
+            template_name=definition.name,
+            template_line=exc.lineno,
+        ) from exc
     except TemplateError as exc:
-        raise PromptTemplateDefinitionError(path=path, details=str(exc)) from exc
+        raise PromptTemplateDefinitionError(
+            details=str(exc),
+            template_name=definition.name,
+        ) from exc
 
     declared_keys = set(definition.parameters)
     if referenced_keys != declared_keys:
         missing = tuple(sorted(referenced_keys - declared_keys))
         unused = tuple(sorted(declared_keys - referenced_keys))
-        msg = (
-            f"Prompt template {definition.name!r} parameters do not match its "
-            f"Jinja variables: missing={missing!r}, unused={unused!r}"
+        details = (
+            "parameters do not match Jinja variables: "
+            f"missing={missing!r}, unused={unused!r}"
         )
-        raise PromptTemplateDefinitionError(path=path, details=msg)
+        raise PromptTemplateDefinitionError(
+            details=details,
+            template_name=definition.name,
+        )
 
     try:
         return _JINJA_ENVIRONMENT.from_string(parsed)
+    except TemplateSyntaxError as exc:
+        raise PromptTemplateDefinitionError(
+            details=exc.message or str(exc),
+            template_name=definition.name,
+            template_line=exc.lineno,
+        ) from exc
     except TemplateError as exc:
-        raise PromptTemplateDefinitionError(path=path, details=str(exc)) from exc
+        raise PromptTemplateDefinitionError(
+            details=str(exc),
+            template_name=definition.name,
+        ) from exc

--- a/tests/unit/common/test_templates.py
+++ b/tests/unit/common/test_templates.py
@@ -6,10 +6,12 @@ from textwrap import dedent
 
 import pytest
 import yaml
-from jinja2 import TemplateError
+from jinja2 import TemplateSyntaxError
+from pydantic import ValidationError
 
 from rampart.common.templates import (
     PromptTemplate,
+    PromptTemplateDefinition,
     PromptTemplateDefinitionError,
     TemplateParameterError,
 )
@@ -37,7 +39,217 @@ def _write_template(tmp_path: Path, **overrides: object) -> Path:
     return _write_yaml(tmp_path, definition)
 
 
+class TestPromptTemplateConstruction:
+    def test_constructs_and_renders_from_definition(self) -> None:
+        definition = PromptTemplateDefinition(
+            name="Greeting",
+            parameters=("subject",),
+            value="Hello, {{ subject }}!",
+            description="Greets a subject.",
+        )
+
+        template = PromptTemplate(definition=definition)
+
+        assert template.name == "Greeting"
+        assert template.description == "Greets a subject."
+        assert template.parameter_keys == ("subject",)
+        assert template.render(subject="Ada") == "Hello, Ada!"
+
+    def test_reports_structured_jinja_syntax_error(self) -> None:
+        definition = PromptTemplateDefinition(
+            name="Broken",
+            parameters=(),
+            value="first template line\n{{ broken",
+        )
+
+        with pytest.raises(PromptTemplateDefinitionError) as exc_info:
+            PromptTemplate(definition=definition)
+
+        assert exc_info.value.template_name == "Broken"
+        assert exc_info.value.template_line == 2
+        assert exc_info.value.path is None
+        assert str(exc_info.value) == (
+            "Prompt template 'Broken' is invalid (template value line 2):\n"
+            f"{exc_info.value.details}"
+        )
+        assert isinstance(exc_info.value.__cause__, TemplateSyntaxError)
+
+    def test_uses_definition_name_for_introspection_error(self) -> None:
+        definition = PromptTemplateDefinition(
+            name="Duplicate blocks",
+            parameters=(),
+            value=(
+                "{% block repeated %}{% endblock %}\n{% block repeated %}{% endblock %}"
+            ),
+        )
+
+        with pytest.raises(PromptTemplateDefinitionError) as exc_info:
+            PromptTemplate(definition=definition)
+
+        assert exc_info.value.template_name == "Duplicate blocks"
+        assert "<introspection>" not in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, TemplateSyntaxError)
+
+    def test_rejects_parameter_declaration_drift(self) -> None:
+        definition = PromptTemplateDefinition(
+            name="Drifted",
+            parameters=("declared_but_unused",),
+            value="{{ referenced_but_missing }}",
+        )
+
+        with pytest.raises(
+            PromptTemplateDefinitionError,
+            match=(
+                r"missing=\('referenced_but_missing',\), "
+                r"unused=\('declared_but_unused',\)"
+            ),
+        ) as exc_info:
+            PromptTemplate(definition=definition)
+
+        assert str(exc_info.value) == (
+            f"Prompt template 'Drifted' is invalid:\n{exc_info.value.details}"
+        )
+
+    def test_does_not_enable_autoescape_from_definition_name(self) -> None:
+        definition = PromptTemplateDefinition(
+            name="summary.html",
+            parameters=("markup",),
+            value="{{ markup }}",
+        )
+
+        template = PromptTemplate(definition=definition)
+
+        assert template.render(markup="<b>") == "<b>"
+
+    @pytest.mark.parametrize(
+        "attribute",
+        ["name", "description", "parameter_keys"],
+    )
+    def test_metadata_properties_are_read_only(self, attribute: str) -> None:
+        template = PromptTemplate(
+            definition=PromptTemplateDefinition(
+                name="Greeting",
+                parameters=("subject",),
+                value="Hello, {{ subject }}!",
+            ),
+        )
+
+        with pytest.raises(AttributeError):
+            setattr(template, attribute, "changed")
+
+    def test_prevents_unknown_attributes(self) -> None:
+        template = PromptTemplate(
+            definition=PromptTemplateDefinition(
+                name="Greeting",
+                parameters=(),
+                value="Hello!",
+            ),
+        )
+
+        assert not hasattr(template, "__dict__")
+
+    def test_uses_identity_equality_and_hashing(self) -> None:
+        definition = PromptTemplateDefinition(
+            name="Greeting",
+            parameters=(),
+            value="Hello!",
+        )
+
+        first = PromptTemplate(definition=definition)
+        second = PromptTemplate(definition=definition)
+
+        assert first != second
+        assert len({first, second}) == 2
+
+    def test_representation_contains_only_public_metadata(self) -> None:
+        template = PromptTemplate(
+            definition=PromptTemplateDefinition(
+                name="Greeting",
+                parameters=("subject",),
+                value="Hidden prompt: {{ subject }}",
+            ),
+        )
+
+        assert repr(template) == (
+            "PromptTemplate(name='Greeting', description=None, "
+            "parameter_keys=('subject',))"
+        )
+        assert "Hidden prompt" not in repr(template)
+
+
+class TestPromptTemplateDefinition:
+    def test_normalizes_parameters_to_immutable_tuple(self) -> None:
+        definition = PromptTemplateDefinition.model_validate(
+            {
+                "name": "Greeting",
+                "parameters": ["subject"],
+                "value": "Hello, {{ subject }}!",
+            },
+        )
+
+        assert definition.parameters == ("subject",)
+        assert not hasattr(definition.parameters, "append")
+
+    def test_rejects_unordered_parameter_collection(self) -> None:
+        with pytest.raises(ValidationError):
+            PromptTemplateDefinition.model_validate(
+                {
+                    "name": "Greeting",
+                    "parameters": {"subject"},
+                    "value": "Hello, {{ subject }}!",
+                },
+            )
+
+    def test_rejects_duplicate_parameters(self) -> None:
+        with pytest.raises(ValidationError, match="items must be unique"):
+            PromptTemplateDefinition.model_validate(
+                {
+                    "name": "Greeting",
+                    "parameters": ["subject", "subject"],
+                    "value": "Hello, {{ subject }}!",
+                },
+            )
+
+    def test_is_hashable_without_exposing_prompt_in_repr(self) -> None:
+        definition = PromptTemplateDefinition(
+            name="Greeting",
+            parameters=("subject",),
+            value="Hidden prompt: {{ subject }}",
+        )
+
+        assert hash(definition)
+        assert "Hidden prompt" not in repr(definition)
+
+    def test_serializes_parameters_as_yaml_sequence(self) -> None:
+        definition = PromptTemplateDefinition(
+            name="Greeting",
+            parameters=("subject",),
+            value="Hello, {{ subject }}!",
+        )
+
+        serialized = yaml.safe_load(yaml.safe_dump(definition.model_dump()))
+
+        assert serialized["parameters"] == ["subject"]
+
+
 class TestPromptTemplateFromYaml:
+    def test_matches_in_memory_construction(self, tmp_path: Path) -> None:
+        path = _write_template(tmp_path, description="Greets a subject.")
+        definition = PromptTemplateDefinition(
+            name="Greeting",
+            parameters=("subject",),
+            value="Hello, {{ subject }}!",
+            description="Greets a subject.",
+        )
+
+        loaded = PromptTemplate.from_yaml(path)
+        in_memory = PromptTemplate(definition=definition)
+
+        assert loaded.name == in_memory.name
+        assert loaded.description == in_memory.description
+        assert loaded.parameter_keys == in_memory.parameter_keys
+        assert loaded.render(subject="Ada") == in_memory.render(subject="Ada")
+
     def test_loads_raw_yaml_block_scalars(self, tmp_path: Path) -> None:
         path = _write_raw_yaml(
             tmp_path,
@@ -97,6 +309,9 @@ class TestPromptTemplateFromYaml:
 
         assert exc_info.value.path == path
         assert exc_info.value.__cause__ is not None
+        assert str(exc_info.value) == (
+            f"Prompt template {path} is invalid:\n{exc_info.value.details}"
+        )
 
     def test_loads_metadata_and_renders_successfully(self, tmp_path: Path) -> None:
         path = _write_template(tmp_path, description="Greets a subject.")
@@ -151,7 +366,41 @@ class TestPromptTemplateFromYaml:
         with pytest.raises(PromptTemplateDefinitionError) as exc_info:
             PromptTemplate.from_yaml(path)
 
-        assert isinstance(exc_info.value.__cause__, TemplateError)
+        assert isinstance(exc_info.value.__cause__, TemplateSyntaxError)
+
+    def test_labels_jinja_line_as_template_value_line(self, tmp_path: Path) -> None:
+        path = _write_raw_yaml(
+            tmp_path,
+            (
+                "name: Broken\n"
+                "parameters: []\n"
+                "description: Demonstrates line mapping\n"
+                "value: |\n"
+                "  first template line\n"
+                "  {{ broken\n"
+            ),
+        )
+        physical_line = next(
+            line_number
+            for line_number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(),
+                start=1,
+            )
+            if "{{ broken" in line
+        )
+
+        with pytest.raises(PromptTemplateDefinitionError) as exc_info:
+            PromptTemplate.from_yaml(path)
+
+        assert physical_line == 6
+        assert exc_info.value.template_line == 2
+        assert exc_info.value.path == path
+        assert str(exc_info.value) == (
+            f"Prompt template 'Broken' loaded from {path} is invalid "
+            f"(template value line 2):\n{exc_info.value.details}"
+        )
+        assert exc_info.value.args == (str(exc_info.value),)
+        assert isinstance(exc_info.value.__cause__, TemplateSyntaxError)
 
     def test_wraps_invalid_utf8(self, tmp_path: Path) -> None:
         path = tmp_path / "prompt.yaml"


### PR DESCRIPTION
## Description

This supersedes the constructor approaches in #132 and #144 and follows the review feedback on #144.

This PR makes prompt-template construction source-neutral while retaining `PromptTemplate.from_yaml(path)` as the YAML and filesystem adapter.

- Adds a public, strict, frozen `PromptTemplateDefinition`.
- Normalizes declared parameters to an immutable, ordered tuple.
- Prevents prompt source from appearing in definition or template representations.
- Replaces injectable dataclass construction with `PromptTemplate(definition=...)`.
- Compiles and validates Jinja exclusively inside `PromptTemplate`.
- Preserves `from_yaml(path)` and both existing production call sites.
- Keeps YAML paths outside the definition and compiled runtime object.
- Preserves direct underlying exception causes while adding YAML path context.
- Reports Jinja line numbers explicitly as template-value lines rather than misleading physical YAML lines.
- Replaces metadata-based equality with object identity.

Jinja receives neither the YAML path nor the logical template name. This avoids incorrect YAML file/line attribution and prevents names such as `summary.html` from unexpectedly enabling autoescape.

## Breaking changes

Direct component-wise construction is no longer accepted:

```python
PromptTemplate(
    name="Greeting",
    description=None,
    parameter_keys=("subject",),
    _template=compiled_template,
)
```

Construct from a validated definition instead:

```python
PromptTemplate(
    definition=PromptTemplateDefinition(
        name="Greeting",
        description=None,
        parameters=("subject",),
        value="Hello, {{ subject }}!",
    ),
)
```

`PromptTemplate.from_yaml(path)` is unchanged, so existing supported call sites require no migration.

Separate `PromptTemplate` instances now use identity equality and hashing rather than metadata-based structural equality. `PromptTemplateDefinitionError.path` is optional for in-memory construction.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Tests added or updated for changes
  - 34 focused prompt-template tests pass
  - 652 tracked unit tests pass
- [x] Documentation updated
  - Module and public API docstrings describe the source-neutral construction and error contracts