### PR TITLE
[CI]: Add flake8 local plugin enforcing the async naming convention

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,27 @@
+[flake8]
+# Flake8 runs ONLY the RAMPART local plugin. Every general-purpose check
+# (pycodestyle, pyflakes, mccabe) is ruff's job, so selecting just RMP keeps
+# the two linters from ever reporting the same problem twice.
+select = RMP
+
+# extend-exclude, not exclude, so flake8's defaults (__pycache__, .tox, .eggs)
+# are kept rather than replaced.
+extend-exclude = .venv,build,dist
+
+# Baseline of pre-existing violations, recorded so the rule can be enforced
+# from day one without a large mechanical rename in the same change. Each
+# entry is removed by the commit that fixes the file. Do not add new entries.
+per-file-ignores =
+    rampart/core/execution.py:RMP001
+    rampart/core/injection.py:RMP001
+    rampart/evaluators/llm_judge.py:RMP001
+    rampart/pyrit_bridge/llm_bridge.py:RMP001
+    rampart/pytest_plugin/_collection.py:RMP001
+    rampart/surfaces/onedrive.py:RMP001
+    tests/*:RMP001
+
+[flake8:local-plugins]
+extension =
+    RMP = flake8_rampart:RampartChecker
+paths =
+    ./tools

--- a/.github/instructions/coding-standards.instructions.md
+++ b/.github/instructions/coding-standards.instructions.md
@@ -619,7 +619,7 @@ rule is a [flake8 local plugin][flake8-local]. It needs no packaging:
 
 Suppress with a same-line `# noqa: RMP001` and a short justification. Note the
 syntax: `# ruff: ignore[...]` is this repository's convention for ruff rules,
-while `# noqa:` is reserved for external codes like `RMP001`, which flake8
+while `# noqa:` is reserved for an RMP code (e.g., `RMP001`), which flake8
 rather than ruff reads. `RMP001` is listed in `[tool.ruff.lint] external` so
 that ruff's `RUF102` accepts it instead of rejecting it as an unknown code.
 

--- a/.github/instructions/coding-standards.instructions.md
+++ b/.github/instructions/coding-standards.instructions.md
@@ -53,6 +53,7 @@ Use parenthesized multi-line imports when importing 3+ names from the same modul
 - **MANDATORY**: All async functions and methods MUST end with `_async` suffix
 - This applies to ALL async functions without exception
 - **Exception**: Dunder methods (`__aenter__`, `__aexit__`, etc.) follow Python's protocol naming and are exempt
+- Enforced by `RMP001` (see [Automated Enforcement](#automated-enforcement))
 
 ```python
 # CORRECT
@@ -600,6 +601,32 @@ Before committing code, ensure:
 - **MANDATORY**: Never use `sed` (or similar stream-editing CLI tools) to modify source files
 - `sed` frequently corrupts files, applies partial edits, or silently fails
 - Always use the editor's built-in replace/edit tools (e.g., `replace_string_in_file`, `multi_replace_string_in_file`) to make targeted, verifiable changes
+
+---
+
+## Automated Enforcement
+
+| Convention | Code | Enforced by |
+|---|---|---|
+| Async `_async` suffix | `RMP001` | `tools/flake8_rampart.py`, a flake8 local plugin |
+
+### Async naming (`RMP001`)
+
+No ruff rule can require a name suffix, and ruff has no plugin system, so this
+rule is a [flake8 local plugin][flake8-local]. It needs no packaging:
+`.flake8` points flake8 at `tools/`, and `select = RMP` ensures flake8 runs
+*only* this check, leaving every general-purpose rule to ruff.
+
+Suppress with a same-line `# noqa: RMP001` and a short justification. Note the
+syntax: `# ruff: ignore[...]` is this repository's convention for ruff rules,
+while `# noqa:` is reserved for external codes like `RMP001`, which flake8
+rather than ruff reads. `RMP001` is listed in `[tool.ruff.lint] external` so
+that ruff's `RUF102` accepts it instead of rejecting it as an unknown code.
+
+`.flake8` carries a `per-file-ignores` baseline of files that predate the rule.
+Those entries are removed as the files are fixed; do not add new ones.
+
+[flake8-local]: https://flake8.pycqa.org/en/latest/user/configuration.html#using-local-plugins
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check .
 
+      - name: RAMPART conventions (flake8-rampart)
+        run: uv run flake8
+
       - name: ty
         run: uv run ty check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       types: [python]
       pass_filenames: false
     - id: flake8-rampart
-      name: flake8-rampart (RMP001)
+      name: flake8-rampart (RMPXXX)
       entry: uv run flake8
       language: system
       # flake8 scans its whole configured scope, so trigger on any Python file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,12 @@ repos:
       language: system
       types: [python]
       pass_filenames: false
+    - id: flake8-rampart
+      name: flake8-rampart (RMP001)
+      entry: uv run flake8
+      language: system
+      # flake8 scans its whole configured scope, so trigger on any Python file
+      # (mirroring the ty hook above) plus the config itself. `types` is omitted
+      # so that .flake8, which is not Python, still triggers the hook.
+      files: (\.py$|^\.flake8$)
+      pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       types: [python]
       pass_filenames: false
     - id: flake8-rampart
-      name: flake8-rampart (RMPXXX)
+      name: flake8-rampart
       entry: uv run flake8
       language: system
       # flake8 scans its whole configured scope, so trigger on any Python file

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -8,7 +8,7 @@ RAMPART enforces a consistent code style through automated tooling and documente
 |------|---------|-----------------|
 | [Ruff](https://docs.astral.sh/ruff/) | Linting and formatting | `pyproject.toml` `[tool.ruff.*]` |
 | [ty](https://github.com/astral-sh/ty) | Static type checking | `pyproject.toml` `[tool.ty]` |
-| [flake8](https://flake8.pycqa.org/) | The one project convention Ruff cannot express | `.flake8`, `tools/flake8_rampart.py` |
+| [flake8](https://flake8.pycqa.org/) | For project conventions Ruff cannot express | `.flake8`, `tools/flake8_rampart.py` |
 | [pre-commit](https://pre-commit.com/) | Git hooks for automated checks | `.pre-commit-config.yaml` |
 
 ### Running Checks
@@ -34,7 +34,7 @@ A few details worth knowing:
 
 - **Ruff** is configured with `select = ["ALL"]`. Test files have relaxed rules (no docstrings, no type annotations, magic values allowed) via `per-file-ignores` in `pyproject.toml`.
 - **ty** targets Python 3.11 — every function needs complete parameter and return type annotations.
-- **flake8** runs only `RMP001` (`select = RMP` in `.flake8`), so it never overlaps Ruff. Suppress it with `# noqa: RMP001`; Ruff rules use `# ruff: ignore[rule-name]`.
+- **flake8** runs only `RMP` codes (`select = RMP` in `.flake8`), so it never overlaps Ruff. Suppress an RMP code with `# noqa: <CODE>` (e.g., `# noqa: RMP001`); Ruff rules use `# ruff: ignore[rule-name]`.
 
 
 ## Key Conventions
@@ -159,7 +159,7 @@ Before committing, run pre-commit — it covers everything the automated tooling
 uv run pre-commit run --all-files
 ```
 
-This runs Ruff (linting + formatting), ty (type checking), and flake8 (`RMP001`), which together enforce the copyright header, type annotations, log formatting, import organization, the `_async` suffix, and most other conventions on this page.
+This runs Ruff (linting + formatting), ty (type checking), and flake8 (`RMPXXX`), which together enforce the copyright header, type annotations, log formatting, import organization, the `_async` suffix, and most other conventions on this page.
 
 A few rules are **not** caught by tooling and still need a human eye:
 

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -8,11 +8,12 @@ RAMPART enforces a consistent code style through automated tooling and documente
 |------|---------|-----------------|
 | [Ruff](https://docs.astral.sh/ruff/) | Linting and formatting | `pyproject.toml` `[tool.ruff.*]` |
 | [ty](https://github.com/astral-sh/ty) | Static type checking | `pyproject.toml` `[tool.ty]` |
+| [flake8](https://flake8.pycqa.org/) | The one project convention Ruff cannot express | `.flake8`, `tools/flake8_rampart.py` |
 | [pre-commit](https://pre-commit.com/) | Git hooks for automated checks | `.pre-commit-config.yaml` |
 
 ### Running Checks
 
-Pre-commit is the primary entry point — it runs Ruff (lint + format) and ty in one command:
+Pre-commit is the primary entry point. It runs Ruff (lint + format), ty, and the RAMPART convention check in one command:
 
 ```bash
 # Install the Git hook once (optional, runs on every commit)
@@ -33,6 +34,7 @@ A few details worth knowing:
 
 - **Ruff** is configured with `select = ["ALL"]`. Test files have relaxed rules (no docstrings, no type annotations, magic values allowed) via `per-file-ignores` in `pyproject.toml`.
 - **ty** targets Python 3.11 — every function needs complete parameter and return type annotations.
+- **flake8** runs only `RMP001` (`select = RMP` in `.flake8`), so it never overlaps Ruff. Suppress it with `# noqa: RMP001`; Ruff rules use `# ruff: ignore[rule-name]`.
 
 
 ## Key Conventions
@@ -60,7 +62,7 @@ async def send_request_async(self, *, payload: str) -> Response: ...
 async def send_request(self, *, payload: str) -> Response: ...
 ```
 
-Dunder methods (`__aenter__`, `__aexit__`) are exempt.
+Dunder methods (`__aenter__`, `__aexit__`) are exempt. Enforced by `RMP001`.
 
 ### Keyword-Only Arguments
 
@@ -157,11 +159,10 @@ Before committing, run pre-commit — it covers everything the automated tooling
 uv run pre-commit run --all-files
 ```
 
-This runs Ruff (linting + formatting) and ty (type checking), which together enforce the copyright header, type annotations, log formatting, import organization, and most other conventions on this page.
+This runs Ruff (linting + formatting), ty (type checking), and flake8 (`RMP001`), which together enforce the copyright header, type annotations, log formatting, import organization, the `_async` suffix, and most other conventions on this page.
 
 A few rules are **not** caught by tooling and still need a human eye:
 
-- [ ] All async functions end with `_async`
 - [ ] Functions with more than one parameter use keyword-only arguments (`*`)
 - [ ] `Enum` / `StrEnum` is used instead of `Literal` for predefined choices
 - [ ] PyRIT imports are lazy (inside functions), not module-level

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -159,7 +159,7 @@ Before committing, run pre-commit — it covers everything the automated tooling
 uv run pre-commit run --all-files
 ```
 
-This runs Ruff (linting + formatting), ty (type checking), and flake8 (`RMPXXX`), which together enforce the copyright header, type annotations, log formatting, import organization, the `_async` suffix, and most other conventions on this page.
+This runs Ruff (linting + formatting), ty (type checking), and flake8 (`RMP` codes), which together enforce the copyright header, type annotations, log formatting, import organization, the `_async` suffix, and most other conventions on this page.
 
 A few rules are **not** caught by tooling and still need a human eye:
 

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -62,7 +62,7 @@ Install the project dependencies using uv:
 uv sync
 ```
 
-`uv sync` installs the project in editable mode and includes the default `dev` group from `pyproject.toml` — ruff, ty, pytest-cov, pytest-xdist, and pre-commit — into a virtual environment managed by uv.
+`uv sync` installs the project in editable mode and includes the default `dev` group from `pyproject.toml` (ruff, ty, flake8, pytest-cov, pytest-xdist, and pre-commit) into a virtual environment managed by uv.
 
 If you also plan to build the documentation locally, include the `docs` group:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ rampart = "rampart.pytest_plugin.plugin"
 
 [dependency-groups]
 dev = [
+    "flake8>=7.3.0",
     "hatch-vcs>=0.5.0",
     "hatchling>=1.30.1",
     "pre-commit>=4.5.1",
@@ -89,7 +90,7 @@ show_missing = true
 skip_empty = true
 
 [tool.pytest.ini_options]
-pythonpath = ["scripts"]
+pythonpath = ["scripts", "tools"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 markers = [
@@ -116,9 +117,16 @@ ignore = [
     "docstring-extraneous-exception", # Allow extraneous exceptions in docstrings to deliberately document the caller-visible contract, even if they propagate from a delegated callee.
 ]
 
+# RMP001 comes from the flake8 local plugin in tools/. Declaring it here stops
+# RUF102 (invalid-rule-code) from rejecting `# noqa: RMP001` as unknown.
+external = ["RMP001"]
+
 [tool.ruff.lint.per-file-ignores]
 "scripts/hatch_build.py" = [
   "implicit-namespace-package", # Top-level build hook
+]
+"tools/flake8_rampart.py" = [
+  "implicit-namespace-package", # flake8 imports it as a top-level module
 ]
 "tests/**" = [
   "any-type",                                          # no type annotations needed
@@ -170,10 +178,10 @@ max-args = 10
 
 [tool.ty.environment]
 python-version = "3.11"
-extra-paths = ["scripts"]
+extra-paths = ["scripts", "tools"]
 
 [tool.ty.src]
-include = ["rampart", "tests", "scripts"]
+include = ["rampart", "tests", "scripts", "tools"]
 
 [tool.uv.sources]
 pyrit = { git = "https://github.com/microsoft/PyRIT", rev = "6dc8b94139757390286bbce7d53c1f7e58e66e29" } # v0.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ ignore = [
     "docstring-extraneous-exception", # Allow extraneous exceptions in docstrings to deliberately document the caller-visible contract, even if they propagate from a delegated callee.
 ]
 
-# RMPXXX comes from the flake8 local plugin in tools/. Declaring it here stops
+# RMP comes from the flake8 local plugin in tools/. Declaring it here stops
 # RUF102 (invalid-rule-code) from rejecting `# noqa: RMPXXX` as unknown.
 external = ["RMP001"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,8 +117,8 @@ ignore = [
     "docstring-extraneous-exception", # Allow extraneous exceptions in docstrings to deliberately document the caller-visible contract, even if they propagate from a delegated callee.
 ]
 
-# RMP001 comes from the flake8 local plugin in tools/. Declaring it here stops
-# RUF102 (invalid-rule-code) from rejecting `# noqa: RMP001` as unknown.
+# RMPXXX comes from the flake8 local plugin in tools/. Declaring it here stops
+# RUF102 (invalid-rule-code) from rejecting `# noqa: RMPXXX` as unknown.
 external = ["RMP001"]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/unit/tools/__init__.py
+++ b/tests/unit/tools/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.

--- a/tests/unit/tools/test_flake8_rampart.py
+++ b/tests/unit/tools/test_flake8_rampart.py
@@ -1,0 +1,99 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Tests for the flake8-rampart local plugin (RMP001)."""
+
+from __future__ import annotations
+
+import ast
+import subprocess  # ruff: ignore[suspicious-subprocess-import]
+import sys
+from pathlib import Path
+
+import pytest
+from flake8_rampart import RampartChecker
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _messages(source: str) -> list[str]:
+    """Return the messages the checker reports for a source snippet."""
+    return [msg for _, _, msg, _ in RampartChecker(ast.parse(source)).run()]
+
+
+class TestAsyncSuffixRule:
+    def test_flags_async_function_without_suffix(self) -> None:
+        (message,) = _messages("async def fetch(): ...")
+        assert message.startswith("RMP001")
+        assert "`fetch`" in message
+
+    def test_accepts_async_function_with_suffix(self) -> None:
+        assert _messages("async def fetch_async(): ...") == []
+
+    def test_ignores_sync_function(self) -> None:
+        assert _messages("def fetch(): ...") == []
+
+    def test_exempts_dunder(self) -> None:
+        assert _messages("async def __aenter__(self): ...") == []
+
+    def test_flags_method_inside_class(self) -> None:
+        source = "class A:\n    async def fetch(self): ...\n"
+        assert len(_messages(source)) == 1
+
+    def test_flags_nested_function(self) -> None:
+        source = "def outer():\n    async def inner(): ...\n"
+        assert len(_messages(source)) == 1
+
+    def test_reports_position_of_definition(self) -> None:
+        checker = RampartChecker(ast.parse("\n\nasync def fetch(): ..."))
+        ((line, col, _, _),) = checker.run()
+        assert (line, col) == (3, 0)
+
+
+@pytest.mark.slow
+class TestPluginWiring:
+    """Guard against the plugin silently failing to load.
+
+    ``flake8 --select=RMP`` exits 0 when no plugin owns the ``RMP`` prefix, so
+    a broken registration would disable the rule with no visible error. These
+    tests run the repository's real ``.flake8`` configuration to prove
+    otherwise.
+    """
+
+    def _run_flake8(self, target: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
+            [sys.executable, "-m", "flake8", str(target)],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_reports_violation_through_flake8(self, tmp_path: Path) -> None:
+        target = tmp_path / "sample.py"
+        target.write_text("async def fetch():\n    pass\n", encoding="utf-8")
+
+        result = self._run_flake8(target)
+
+        assert result.returncode == 1
+        assert "RMP001" in result.stdout
+
+    def test_honors_noqa_through_flake8(self, tmp_path: Path) -> None:
+        target = tmp_path / "sample.py"
+        target.write_text(
+            "async def fetch():  # noqa: RMP001\n    pass\n",
+            encoding="utf-8",
+        )
+
+        result = self._run_flake8(target)
+
+        assert result.returncode == 0, result.stdout
+
+    def test_runs_no_rules_other_than_rmp(self, tmp_path: Path) -> None:
+        """``select = RMP`` keeps pycodestyle and pyflakes off; that is ruff's job."""
+        target = tmp_path / "sample.py"
+        target.write_text("import os\nx=1\n", encoding="utf-8")
+
+        result = self._run_flake8(target)
+
+        assert result.returncode == 0, result.stdout

--- a/tools/flake8_rampart.py
+++ b/tools/flake8_rampart.py
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Flake8 plugin for RAMPART conventions that ruff cannot express.
+
+Registered as a flake8 *local plugin*: see the ``[flake8:local-plugins]``
+section of ``.flake8``. Local plugins need no packaging or installation:
+flake8 adds ``tools/`` to ``sys.path`` and imports this module directly.
+
+Rules:
+    RMP001: Async functions must be named with an ``_async`` suffix.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+RMP001 = "RMP001 async function `{name}` must be named with an `_async` suffix"
+
+
+def _is_dunder(name: str) -> bool:
+    """Return whether a name follows Python's ``__dunder__`` convention.
+
+    Args:
+        name (str): The function name to test.
+
+    Returns:
+        bool: True for names like ``__aenter__`` that Python itself defines.
+    """
+    return name.startswith("__") and name.endswith("__")
+
+
+class RampartChecker:
+    """Flake8 checker enforcing RAMPART's async naming convention."""
+
+    name: ClassVar[str] = "flake8-rampart"
+    version: ClassVar[str] = "1.0.0"
+
+    def __init__(self, tree: ast.AST) -> None:
+        """Store the module AST supplied by flake8.
+
+        Args:
+            tree (ast.AST): Parsed syntax tree for the file under check.
+        """
+        self._tree = tree
+
+    def run(self) -> Iterator[tuple[int, int, str, type]]:
+        """Yield a violation for every async function missing the suffix.
+
+        Yields:
+            tuple[int, int, str, type]: Line, column, message, and checker
+                type, in the 4-tuple shape flake8 expects.
+        """
+        for node in ast.walk(self._tree):
+            if not isinstance(node, ast.AsyncFunctionDef):
+                continue
+            # Dunders implement Python protocols; their names are not ours to choose.
+            if _is_dunder(node.name) or node.name.endswith("_async"):
+                continue
+            yield (
+                node.lineno,
+                node.col_offset,
+                RMP001.format(name=node.name),
+                type(self),
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -817,6 +817,20 @@ wheels = [
 ]
 
 [[package]]
+name = "flake8"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1574,6 +1588,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -2574,6 +2597,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2699,6 +2731,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -3042,6 +3083,7 @@ onedrive = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "flake8" },
     { name = "hatch-vcs" },
     { name = "hatchling" },
     { name = "pre-commit" },
@@ -3073,6 +3115,7 @@ provides-extras = ["onedrive"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "flake8", specifier = ">=7.3.0" },
     { name = "hatch-vcs", specifier = ">=0.5.0" },
     { name = "hatchling", specifier = ">=1.30.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },


### PR DESCRIPTION
## Description

Follow-up to #22 (closed unmerged), taking @nina-msft's suggestion to use a flake8 plugin instead of a custom linter. Covers the `_async` naming rule only.

69 lines instead of 811. No source files change.

flake8 supplies the noqa parser, CLI, file discovery and rule dispatch that #22 hand-built. What remains is the rule itself, ~9 lines.

Two deviations from the suggested snippet:

- **Prefix is `RMP`, not `RAMPART`.** flake8 validates codes against `^[A-Z]{1,3}[0-9]{0,3}$` and refuses to start otherwise.
- **No packaging.** [Local plugins](https://flake8.pycqa.org/en/latest/user/configuration.html#using-local-plugins) drop the entry point: `.flake8` points at `tools/`. Nothing ships in the `rampart` wheel.

On running two linters: ruff [has no plugin system](https://docs.astral.sh/ruff/faq/#does-ruff-support-plugins) and no rule for name suffixes. `select = RMP` means flake8 runs only this rule, so it never overlaps ruff.

### Baseline

159 pre-existing violations are recorded as `per-file-ignores` in `.flake8` rather than fixed here, keeping this diff reviewable. The rule is live now; follow-up commits shrink the baseline to nothing.

### Silent no-op guard

`flake8 --select=RMP` exits 0 if nothing owns the prefix. Mitigated two ways: any load failure is a hard error (exit 1), and 3 subprocess tests run the real `.flake8` config to assert the rule actually fires.

### Notes

- `RMP001` is in `[tool.ruff.lint] external` so `RUF102` accepts `# noqa: RMP001`. Split: `# ruff: ignore[rule]` for ruff, `# noqa:` for flake8.
- Pre-commit hook triggers on `.flake8` too, so config edits can't skip it and fail CI later.

## Breaking changes

None.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Tests added or updated for changes — 10 in `tests/unit/tools/test_flake8_rampart.py`: 7 unit (dunder exemption, nested/class-level defs, sync ignored, position) + 3 subprocess (registration, noqa, `select` scoping)
- [x] Documentation updated — Automated Enforcement section in `coding-standards.instructions.md`; `code-style.md` (which still said this rule needed "a human eye") and `development-setup.md`