### PR TITLE
[FEAT]: Stream xdist results through test reports

### DIFF
--- a/docs/api/pytest-plugin.md
+++ b/docs/api/pytest-plugin.md
@@ -17,8 +17,9 @@ RAMPART's pytest integration. Activates automatically when installed.
 
 ## Parallel Execution Hooks
 
-When `pytest-xdist` is installed, the plugin streams call-phase Result envelopes
-through `pytest_runtest_logreport` and uses the optional `pytest_testnodedown`
+When `pytest-xdist` is installed, the plugin streams Result envelopes on call
+reports, with a non-passing setup fallback when no call report will occur,
+through `pytest_runtest_logreport`. It uses the optional `pytest_testnodedown`
 hook to reconcile per-worker Result counts. See
 [Parallel Execution](../usage/xdist.md) for the data flow and trust boundary.
 

--- a/docs/api/pytest-plugin.md
+++ b/docs/api/pytest-plugin.md
@@ -17,7 +17,10 @@ RAMPART's pytest integration. Activates automatically when installed.
 
 ## Parallel Execution Hooks
 
-When `pytest-xdist` is installed, the plugin registers `pytest_testnodedown` (as an optional hook) to merge worker results into the controller session. See [Parallel Execution](../usage/xdist.md) for the data flow and trust boundary.
+When `pytest-xdist` is installed, the plugin streams call-phase Result envelopes
+through `pytest_runtest_logreport` and uses the optional `pytest_testnodedown`
+hook to reconcile per-worker Result counts. See
+[Parallel Execution](../usage/xdist.md) for the data flow and trust boundary.
 
 ::: rampart.pytest_plugin._xdist
     options:
@@ -26,6 +29,7 @@ When `pytest-xdist` is installed, the plugin registers `pytest_testnodedown` (as
         - WORKEROUTPUT_KEY
         - SIZE_LIMIT_OPTION
         - DEFAULT_SIZE_LIMIT_BYTES
+        - MIN_RESULT_SIZE_LIMIT_BYTES
         - WorkerOutputError
         - SchemaVersionError
         - SizeLimitError
@@ -33,8 +37,12 @@ When `pytest-xdist` is installed, the plugin registers `pytest_testnodedown` (as
         - is_xdist_controller
         - get_dist_mode
         - get_worker_count
+        - attach_report_results
+        - serialize_report_data
+        - deserialize_report_data
+        - merge_report_results
         - serialize_worker_data
-        - deserialize_worker_data
+        - deserialize_trial_specs
         - finalize_worker
         - handle_testnodedown
         - discover_sinks_from_conftest

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -61,10 +61,10 @@ Subclasses implement only `_execute_async` and `strategy_name`. They should **no
 
 `pytest_plugin/` integrates RAMPART with pytest:
 
-- `plugin.py` — hook registrations (configure, collection, sessionfinish, terminal summary, optional `pytest_testnodedown`).
+- `plugin.py` — hook registrations (configure, collection, call-report streaming, sessionfinish, terminal summary, optional `pytest_testnodedown`).
 - `_session.py` — session-scoped state container (`RampartSession`), trial-group aggregates, sink registry, idempotency and incomplete-run flags.
 - `_collection.py` — per-test `ResultCollector` and the `ContextVar`-based handler that captures results from executions.
-- `_xdist.py` — pytest-xdist support: detection helpers, JSON-safe serialization of `Result` objects, controller-side merge, and conftest-scanning sink discovery. Workers serialize their results into `config.workeroutput`; the controller deserializes via `pytest_testnodedown` and emits a single unified report. See [Parallel Execution](../usage/xdist.md) for the data flow and trust boundary.
+- `_xdist.py` — pytest-xdist support: detection helpers, JSON-safe serialization of `Result` objects, controller-side merge, and conftest-scanning sink discovery. Workers stream call-phase Results on `TestReport` objects; the controller merges them through `pytest_runtest_logreport`, reconciles counts at `pytest_testnodedown`, and emits a single unified report. See [Parallel Execution](../usage/xdist.md) for the data flow and trust boundary.
 
 ### PyRIT Bridge
 

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -61,10 +61,10 @@ Subclasses implement only `_execute_async` and `strategy_name`. They should **no
 
 `pytest_plugin/` integrates RAMPART with pytest:
 
-- `plugin.py` — hook registrations (configure, collection, call-report streaming, sessionfinish, terminal summary, optional `pytest_testnodedown`).
+- `plugin.py` — hook registrations (configure, collection, report streaming, sessionfinish, terminal summary, optional `pytest_testnodedown`).
 - `_session.py` — session-scoped state container (`RampartSession`), trial-group aggregates, sink registry, idempotency and incomplete-run flags.
 - `_collection.py` — per-test `ResultCollector` and the `ContextVar`-based handler that captures results from executions.
-- `_xdist.py` — pytest-xdist support: detection helpers, JSON-safe serialization of `Result` objects, controller-side merge, and conftest-scanning sink discovery. Workers stream call-phase Results on `TestReport` objects; the controller merges them through `pytest_runtest_logreport`, reconciles counts at `pytest_testnodedown`, and emits a single unified report. See [Parallel Execution](../usage/xdist.md) for the data flow and trust boundary.
+- `_xdist.py` — pytest-xdist support: detection helpers, JSON-safe serialization of `Result` objects, controller-side merge, and conftest-scanning sink discovery. Workers stream Results on call reports, or on non-passing setup reports when no call report will occur; the controller merges them through `pytest_runtest_logreport`, reconciles counts at `pytest_testnodedown`, and emits a single unified report. See [Parallel Execution](../usage/xdist.md) for the data flow and trust boundary.
 
 ### PyRIT Bridge
 

--- a/docs/usage/ci-integration.md
+++ b/docs/usage/ci-integration.md
@@ -79,7 +79,7 @@ RAMPART is configured via pytest options and Python (sinks, adapters, payloads).
 
 ### `--rampart-xdist-max-bytes`
 
-Maximum size in bytes of a worker's serialized result payload when running under [`pytest-xdist`](xdist.md). Defaults to `67108864` (64 MB). Workers that exceed the cap log a warning and the controller marks the run as incomplete. Also configurable via the `rampart_xdist_max_bytes` ini option.
+Maximum size in bytes of each serialized Result when running under [`pytest-xdist`](xdist.md). Defaults to `16777216` (16 MiB). Oversized Results are replaced by truncation markers and the controller marks the run as incomplete. Also configurable via the `rampart_xdist_max_bytes` ini option.
 
 ```bash
 pytest -n auto --rampart-xdist-max-bytes=134217728   # 128 MB
@@ -141,5 +141,4 @@ RAMPART does not alter pytest's exit codes:
 | `1` | Some tests failed |
 | `2` | Test execution interrupted |
 | `5` | No tests collected |
-
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -10,7 +10,7 @@ RAMPART exposes one pytest option for parallel-execution tuning. Other component
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--rampart-xdist-max-bytes` (CLI) / `rampart_xdist_max_bytes` (ini) | `67108864` (64 MB) | Maximum size of a worker's serialized result payload when running under [`pytest-xdist`](xdist.md). Workers exceeding the cap are recorded as incomplete in `TestRunReport.metadata`. |
+| `--rampart-xdist-max-bytes` (CLI) / `rampart_xdist_max_bytes` (ini) | `16777216` (16 MiB) | Maximum size of each serialized Result when running under [`pytest-xdist`](xdist.md). Oversized Results are replaced by truncation markers and recorded as incomplete in `TestRunReport.metadata`. |
 
 ---
 
@@ -116,5 +116,4 @@ manifest.declares_tool("send_email")  # True
 manifest.get_tool("send_email")       # ToolDeclaration(name="send_email", ...)
 manifest.get_tool("nonexistent")      # None
 ```
-
 

--- a/docs/usage/xdist.md
+++ b/docs/usage/xdist.md
@@ -20,7 +20,7 @@ With `-n 4`, pytest spawns 4 worker processes that execute tests in parallel. RA
 ```
 Worker 1                    Worker 2                    Controller
 ─────────                   ─────────                   ──────────
-call-phase Results           call-phase Results
+eligible Results             eligible Results
     │                           │
 serialize → TestReport      serialize → TestReport
     │                           │
@@ -41,12 +41,14 @@ serialize → TestReport      serialize → TestReport
         Single unified TestRunReport
 ```
 
-- **Workers** attach JSON-safe serialized [`Result`][rampart.core.result.Result] objects to each call-phase `TestReport`. Workers do **not** emit RAMPART report sinks.
+- **Workers** attach JSON-safe serialized [`Result`][rampart.core.result.Result] objects to each call-phase `TestReport`, or to a non-passing setup report when setup recorded Results and no call report will occur. Workers do **not** emit RAMPART report sinks.
 - **Controller** receives each envelope through `pytest_runtest_logreport`, validates and merges it into its [`RampartSession`][rampart.pytest_plugin._session.RampartSession], and emits sinks once at session end.
 - **Worker shutdown** carries only trial specifications and the expected number of streamed Result representations in `config.workeroutput`. The controller reconciles that count in `pytest_testnodedown`; Results are never delivered through both paths.
 
-The call phase is the intentional transport boundary. Results recorded during
-fixture teardown are not streamed.
+The normal transport boundary is the call phase, which includes Results recorded
+during successful fixture setup. A failed or skipped setup that recorded Results
+uses its setup report as a fallback because no call report follows. Results
+recorded during fixture teardown are not streamed.
 
 The result: **one** `JsonFileReportSink` output file, **one** call to `MyCustomSink.emit_async`, and accurate population statistics over the full result set.
 
@@ -243,7 +245,7 @@ report.metadata["dist_mode"]      # "load", "loadgroup", etc.
 
 ## Durability behavior
 
-Each call-phase report is merged as it reaches the controller. If a worker is
+Each eligible report is merged as it reaches the controller. If a worker is
 killed mid-run, every Result already delivered remains in the final report and
 the run is marked incomplete because the worker cannot provide a final expected
 count. A clean worker shutdown publishes its emitted Result count; any mismatch
@@ -260,9 +262,9 @@ does not discard normal Results from that worker.
 - Sinks discovered through the **fixture fallback** on the controller cannot depend
   on other pytest fixtures — use the `pytest_rampart_sinks` hook instead (see
   [Registering Sinks](#registering-sinks-the-pytest_rampart_sinks-hook)).
-- Results recorded only during fixture teardown are outside the call-phase
-  streaming boundary and are not included.
-- A worker that dies can lose Results whose call-phase reports had not reached
+- Results recorded only during fixture teardown are outside the report-streaming
+  boundary and are not included.
+- A worker that dies can lose Results whose eligible reports had not reached
   the controller; already-streamed Results are retained and the run is marked
   incomplete (see [Durability behavior](#durability-behavior)).
 - Mixed RAMPART versions across controller and workers are unsupported; install the

--- a/docs/usage/xdist.md
+++ b/docs/usage/xdist.md
@@ -20,17 +20,18 @@ With `-n 4`, pytest spawns 4 worker processes that execute tests in parallel. RA
 ```
 Worker 1                    Worker 2                    Controller
 ─────────                   ─────────                   ──────────
-collect results             collect results
+call-phase Results           call-phase Results
     │                           │
-pytest_sessionfinish        pytest_sessionfinish
-    │                           │
-serialize → workeroutput    serialize → workeroutput
+serialize → TestReport      serialize → TestReport
     │                           │
     └───────────┬───────────────┘
                 ▼
-        pytest_testnodedown (per worker)
-        deserialize + merge into
-        controller's RampartSession
+        pytest_runtest_logreport
+        validate + merge incrementally
+                │
+                ▼
+        pytest_testnodedown
+        reconcile streamed Result counts
                 │
                 ▼
         pytest_sessionfinish (controller)
@@ -40,8 +41,12 @@ serialize → workeroutput    serialize → workeroutput
         Single unified TestRunReport
 ```
 
-- **Workers** collect [`Result`][rampart.core.result.Result] objects normally and serialize them into `config.workeroutput`. Workers do **not** emit reports.
-- **Controller** receives each worker's payload via the `pytest_testnodedown` hook, merges results into its own [`RampartSession`][rampart.pytest_plugin._session.RampartSession], and emits sinks once at session end.
+- **Workers** attach JSON-safe serialized [`Result`][rampart.core.result.Result] objects to each call-phase `TestReport`. Workers do **not** emit RAMPART report sinks.
+- **Controller** receives each envelope through `pytest_runtest_logreport`, validates and merges it into its [`RampartSession`][rampart.pytest_plugin._session.RampartSession], and emits sinks once at session end.
+- **Worker shutdown** carries only trial specifications and the expected number of streamed Result representations in `config.workeroutput`. The controller reconciles that count in `pytest_testnodedown`; Results are never delivered through both paths.
+
+The call phase is the intentional transport boundary. Results recorded during
+fixture teardown are not streamed.
 
 The result: **one** `JsonFileReportSink` output file, **one** call to `MyCustomSink.emit_async`, and accurate population statistics over the full result set.
 
@@ -184,7 +189,7 @@ Worker payloads cross a process boundary via `execnet` and may contain attacker-
 
 - **Arbitrary code execution** — strict JSON-safe primitives only; no `pickle`, `marshal`, or custom `__reduce__`.
 - **Schema drift** — payloads with missing or unknown schema versions are rejected fail-closed.
-- **Memory exhaustion** — worker payloads are capped at 64 MB by default.
+- **Memory exhaustion** — each serialized Result is capped at 64 MB by default.
 - **Terminal/log injection** — ANSI escape sequences are stripped from free-form text at the deserialization boundary.
 - **Path traversal** — worker-local artifact paths are stored as opaque strings in metadata; the controller never accesses worker files.
 
@@ -203,13 +208,17 @@ Or in `pytest.ini` / `pyproject.toml`:
 rampart_xdist_max_bytes = 134217728
 ```
 
-Workers that exceed the cap log a warning and emit a truncation marker. The controller records the affected worker as incomplete in `TestRunReport.metadata`.
+An oversized Result is replaced by an attributed ERROR/truncation marker while
+normal Results from the same worker continue to stream. The controller records
+the run as incomplete in `TestRunReport.metadata`. Configured limits below 4 KiB
+use a 4 KiB effective minimum so the marker itself always fits.
 
 ---
 
 ## Incomplete Runs
 
-If a worker crashes, runs out of time, or hits the size cap, the controller marks the run as incomplete:
+If a worker crashes, drops a streamed Result, omits its final count, or hits the
+size cap, the controller marks the run as incomplete:
 
 ```python
 report.metadata["incomplete"]            # True if any worker failed
@@ -232,27 +241,17 @@ report.metadata["dist_mode"]      # "load", "loadgroup", etc.
 
 ---
 
-## Durability limitations
+## Durability behavior
 
-The current worker→controller transport flushes a worker's results only at its
-clean `pytest_sessionfinish`. This has two consequences you should be aware of:
+Each call-phase report is merged as it reaches the controller. If a worker is
+killed mid-run, every Result already delivered remains in the final report and
+the run is marked incomplete because the worker cannot provide a final expected
+count. A clean worker shutdown publishes its emitted Result count; any mismatch
+with the controller's received count detects a silent drop and also marks the run
+incomplete.
 
-- **A worker killed mid-run loses its already-finished results.** Because results
-  are shipped in a single batch at session end, a worker that crashes, is killed
-  (e.g. OOM, timeout, `-x` shutdown), or otherwise never reaches
-  `pytest_sessionfinish` contributes **nothing** — even tests it had already
-  completed. The run is marked incomplete (see [Incomplete Runs](#incomplete-runs)).
-- **The size cap drops the whole worker payload, not just the oversized record.**
-  When a worker's aggregate serialized payload exceeds
-  `--rampart-xdist-max-bytes`, the **entire** worker payload is dropped (and the
-  worker marked incomplete), rather than only the single oversized transcript.
-
-Both behaviors are deliberate fail-closed choices for this release. A durable
-per-worker transport (incremental JSONL shards that survive a killed worker, with
-the size cap applied per-record) is in progress as a follow-up change; until it
-lands, use `--dist=loadgroup` only when your trial groups need worker cohesion (see
-[Choosing `loadgroup` vs `load`](#choosing-loadgroup-vs-load)) and size your cap to
-your largest expected worker payload.
+The cap applies independently to each Result. An oversized transcript therefore
+does not discard normal Results from that worker.
 
 ---
 
@@ -261,9 +260,11 @@ your largest expected worker payload.
 - Sinks discovered through the **fixture fallback** on the controller cannot depend
   on other pytest fixtures — use the `pytest_rampart_sinks` hook instead (see
   [Registering Sinks](#registering-sinks-the-pytest_rampart_sinks-hook)).
-- Results from a worker that dies before `pytest_sessionfinish` are lost, and an
-  over-cap worker payload is dropped wholesale (see
-  [Durability limitations](#durability-limitations)).
+- Results recorded only during fixture teardown are outside the call-phase
+  streaming boundary and are not included.
+- A worker that dies can lose Results whose call-phase reports had not reached
+  the controller; already-streamed Results are retained and the run is marked
+  incomplete (see [Durability behavior](#durability-behavior)).
 - Mixed RAMPART versions across controller and workers are unsupported; install the
   same version everywhere.
 - `pytest-xdist` itself does not support interactive debugging (`--pdb`, `--trace`);

--- a/docs/usage/xdist.md
+++ b/docs/usage/xdist.md
@@ -189,13 +189,13 @@ Worker payloads cross a process boundary via `execnet` and may contain attacker-
 
 - **Arbitrary code execution** — strict JSON-safe primitives only; no `pickle`, `marshal`, or custom `__reduce__`.
 - **Schema drift** — payloads with missing or unknown schema versions are rejected fail-closed.
-- **Memory exhaustion** — each serialized Result is capped at 64 MB by default.
+- **Memory exhaustion** — each serialized Result is capped at 16 MiB by default.
 - **Terminal/log injection** — ANSI escape sequences are stripped from free-form text at the deserialization boundary.
 - **Path traversal** — worker-local artifact paths are stored as opaque strings in metadata; the controller never accesses worker files.
 
 ### Size cap
 
-The default 64 MB cap can be overridden via the pytest CLI option or an ini setting:
+The default 16 MiB cap can be overridden via the pytest CLI option or an ini setting:
 
 ```bash
 pytest -n 4 --rampart-xdist-max-bytes=134217728

--- a/rampart/pytest_plugin/_session.py
+++ b/rampart/pytest_plugin/_session.py
@@ -47,6 +47,34 @@ def _result_sort_key(result: Result) -> tuple[str, int, str]:
     return (nodeid, index, source_worker)
 
 
+def tag_collected_results(
+    *,
+    node: pytest.Item,
+    results: Sequence[Result],
+) -> list[Result]:
+    """Copy and tag Results with their pytest item metadata.
+
+    Returns:
+        list[Result]: Tagged shallow copies in their original order.
+    """
+    test_name = node.nodeid.split("::")[-1] if "::" in node.nodeid else node.nodeid
+    harm_marker = node.get_closest_marker("harm")
+    harm_category = harm_marker.args[0] if harm_marker and harm_marker.args else None
+    tagged: list[Result] = []
+    for result_index, original_result in enumerate(results):
+        result = copy.copy(original_result)
+        result.metadata = {
+            **result.metadata,
+            "_pytest_test_name": test_name,
+            "_pytest_nodeid": node.nodeid,
+            "_rampart_result_index": result_index,
+        }
+        if harm_category is not None and result.harm_category is None:
+            result.harm_category = harm_category
+        tagged.append(result)
+    return tagged
+
+
 @dataclass(frozen=True, kw_only=True)
 class TrialSpec:
     """Trial-clone metadata captured at collection time.
@@ -203,27 +231,7 @@ class RampartSession:
             node (pytest.Item): The test item that just completed.
             collector (ResultCollector): The test's result collector.
         """
-        test_name = node.nodeid.split("::")[-1] if "::" in node.nodeid else node.nodeid
-        harm_marker = node.get_closest_marker("harm")
-        harm_category = (
-            harm_marker.args[0] if harm_marker and harm_marker.args else None
-        )
-
-        collected = collector.results
-        tagged: list[Result] = []
-        for result_index, original_result in enumerate(collected):
-            # Shallow copy is sufficient because we reconstruct all
-            # mutable fields we modify (currently metadata and harm_category).
-            result = copy.copy(original_result)
-            result.metadata = {
-                **result.metadata,
-                "_pytest_test_name": test_name,
-                "_pytest_nodeid": node.nodeid,
-                "_rampart_result_index": result_index,
-            }
-            if harm_category is not None and result.harm_category is None:
-                result.harm_category = harm_category
-            tagged.append(result)
+        tagged = tag_collected_results(node=node, results=collector.results)
         self._results.extend(tagged)
         self._results_by_nodeid[node.nodeid] = tagged
         self._cached_report = None
@@ -385,7 +393,8 @@ class RampartSession:
                 in the report metadata.
         """
         self._incomplete = True
-        self._incomplete_reasons.append(reason)
+        if reason not in self._incomplete_reasons:
+            self._incomplete_reasons.append(reason)
         self._cached_report = None
 
     def set_report_metadata(self, *, metadata: dict[str, object]) -> None:

--- a/rampart/pytest_plugin/_session.py
+++ b/rampart/pytest_plugin/_session.py
@@ -57,7 +57,7 @@ def tag_collected_results(
     Returns:
         list[Result]: Tagged shallow copies in their original order.
     """
-    test_name = node.nodeid.split("::")[-1] if "::" in node.nodeid else node.nodeid
+    test_name = node.name
     harm_marker = node.get_closest_marker("harm")
     harm_category = harm_marker.args[0] if harm_marker and harm_marker.args else None
     tagged: list[Result] = []

--- a/rampart/pytest_plugin/_xdist.py
+++ b/rampart/pytest_plugin/_xdist.py
@@ -4,10 +4,9 @@
 """xdist support for RAMPART's pytest plugin.
 
 Provides serialization, deserialization, and controller-side merge
-logic for running RAMPART under pytest-xdist. Workers serialize their
-``Result`` objects into ``config.workeroutput``; the controller merges
-worker payloads in ``pytest_testnodedown`` and emits a single unified
-report at session end.
+logic for running RAMPART under pytest-xdist. Workers stream ``Result``
+objects on call-phase test reports; the controller merges each report
+incrementally and emits a single unified report at session end.
 
 Trust boundary: worker payloads may contain attacker-controlled
 content (agent responses, payload text). Serialization is strictly
@@ -57,13 +56,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION: str = "rampart.xdist.v1"
-WORKEROUTPUT_KEY: str = "rampart_xdist_v1"
+SCHEMA_VERSION: str = "rampart.xdist.v2"
+WORKEROUTPUT_KEY: str = "rampart_xdist_v2"
+REPORT_RESULTS_ATTR: str = "_rampart_results"
 SIZE_LIMIT_OPTION: str = "rampart_xdist_max_bytes"
 DEFAULT_SIZE_LIMIT_BYTES: int = 64 * 1024 * 1024
+MIN_RESULT_SIZE_LIMIT_BYTES: int = 4 * 1024
 MAX_METADATA_DEPTH: int = 6
 
 _TRUNCATED_MARKER: str = "rampart_truncated"
+_TRUNCATED_ATTRIBUTION_MAX_BYTES: int = 512
+_TRUNCATED_FALLBACK_ATTRIBUTION_MAX_BYTES: int = 64
+_STREAMED_RESULT_COUNT: str = "streamed_result_count"
 
 
 class WorkerOutputError(Exception):
@@ -75,7 +79,7 @@ class SchemaVersionError(WorkerOutputError):
 
 
 class SizeLimitError(WorkerOutputError):
-    """Raised when a worker payload exceeds the configured size cap."""
+    """Raised when one serialized Result exceeds the configured size cap."""
 
 
 def is_xdist_worker(*, config: pytest.Config) -> bool:
@@ -144,7 +148,7 @@ def get_worker_count(*, config: pytest.Config) -> int:
 
 
 def _size_limit(*, config: pytest.Config) -> int:
-    """Resolve the worker payload size cap from pytest config or default.
+    """Resolve the per-Result size cap from pytest config or default.
 
     Reads from the ``--rampart-xdist-max-bytes`` CLI option first, then
     the ``rampart_xdist_max_bytes`` ini option, then falls back to
@@ -180,6 +184,15 @@ def _size_limit(*, config: pytest.Config) -> int:
             DEFAULT_SIZE_LIMIT_BYTES,
         )
         return DEFAULT_SIZE_LIMIT_BYTES
+    if parsed < MIN_RESULT_SIZE_LIMIT_BYTES:
+        logger.warning(
+            "%s=%d is below the minimum %d bytes required for an attributed "
+            "truncation marker; using the minimum.",
+            SIZE_LIMIT_OPTION,
+            parsed,
+            MIN_RESULT_SIZE_LIMIT_BYTES,
+        )
+        return MIN_RESULT_SIZE_LIMIT_BYTES
     return parsed
 
 
@@ -498,29 +511,237 @@ def _serialize_result(*, result: Result, nodeid: str) -> dict[str, Any]:
     }
 
 
-def serialize_worker_data(*, session: RampartSession) -> dict[str, Any]:
-    """Serialize a worker's RampartSession state for transport to the controller.
+def _serialized_size(*, data: dict[str, Any]) -> int:
+    """Return the UTF-8 JSON size of serialized transport data."""
+    encoded = json.dumps(data, default=str)
+    return len(encoded.encode("utf-8"))
 
-    Produces a JSON-safe dict containing the schema version, the
-    package version (for cross-version diagnostics), the worker's
-    ``_results_by_nodeid`` mapping serialized to primitive types,
-    and trial specs registered during collection.
+
+def _enforce_result_size(
+    *,
+    size_bytes: int,
+    limit_bytes: int,
+    nodeid: str,
+) -> None:
+    """Raise when one serialized Result exceeds its transport cap.
+
+    Raises:
+        SizeLimitError: If the serialized Result exceeds the cap.
+    """
+    if size_bytes <= limit_bytes:
+        return
+    display_nodeid = _bounded_attribution(
+        value=nodeid,
+        max_bytes=_TRUNCATED_ATTRIBUTION_MAX_BYTES,
+    )
+    msg = (
+        f"Result for {display_nodeid!r} is {size_bytes} bytes, exceeding the "
+        f"{limit_bytes}-byte xdist transport cap. Increase "
+        f"--{SIZE_LIMIT_OPTION.replace('_', '-')} (or the "
+        f"{SIZE_LIMIT_OPTION} ini option) to raise the cap."
+    )
+    raise SizeLimitError(msg)
+
+
+def _truncated_result_data(
+    *,
+    result: Result,
+    nodeid: str,
+    size_bytes: int,
+    limit_bytes: int,
+) -> dict[str, Any]:
+    """Build a bounded ERROR Result marker for oversized transport data.
+
+    Returns:
+        dict[str, Any]: JSON-safe truncated Result data.
+    """
+    raw_test_name = result.metadata.get("_pytest_test_name")
+    test_name = (
+        str(raw_test_name)
+        if raw_test_name is not None
+        else nodeid.rsplit("::", maxsplit=1)[-1]
+    )
+    harm_category = (
+        str(result.harm_category) if result.harm_category is not None else None
+    )
+    marker = {
+        _TRUNCATED_MARKER: True,
+        "safe": False,
+        "status": SafetyStatus.ERROR.value,
+        "summary": (
+            "RAMPART Result exceeded the xdist transport size cap; "
+            "full content was truncated."
+        ),
+        "turns": [],
+        "duration_seconds": 0.0,
+        "harm_category": _bounded_attribution(
+            value=harm_category,
+            max_bytes=_TRUNCATED_ATTRIBUTION_MAX_BYTES,
+        ),
+        "strategy": "xdist-transport",
+        "observability_level": ObservabilityLevel.RESPONSE_ONLY.value,
+        "injections": [],
+        "metadata": {
+            "_pytest_test_name": _bounded_attribution(
+                value=test_name,
+                max_bytes=_TRUNCATED_ATTRIBUTION_MAX_BYTES,
+            ),
+            "_pytest_nodeid": _bounded_attribution(
+                value=nodeid,
+                max_bytes=_TRUNCATED_ATTRIBUTION_MAX_BYTES,
+            ),
+            "_rampart_transport_truncated": True,
+            "_rampart_original_size_bytes": size_bytes,
+            "_rampart_limit_bytes": limit_bytes,
+        },
+    }
+    if _serialized_size(data=marker) <= limit_bytes:
+        return marker
+    logger.warning(
+        "Compacting truncation marker for %s to fit the %d-byte transport cap.",
+        _bounded_attribution(
+            value=nodeid,
+            max_bytes=_TRUNCATED_FALLBACK_ATTRIBUTION_MAX_BYTES,
+        ),
+        limit_bytes,
+    )
+    marker["harm_category"] = _bounded_attribution(
+        value=harm_category,
+        max_bytes=_TRUNCATED_FALLBACK_ATTRIBUTION_MAX_BYTES,
+    )
+    marker_metadata = cast("dict[str, Any]", marker["metadata"])
+    marker_metadata["_pytest_test_name"] = _bounded_attribution(
+        value=test_name,
+        max_bytes=_TRUNCATED_FALLBACK_ATTRIBUTION_MAX_BYTES,
+    )
+    marker_metadata["_pytest_nodeid"] = _bounded_attribution(
+        value=nodeid,
+        max_bytes=_TRUNCATED_FALLBACK_ATTRIBUTION_MAX_BYTES,
+    )
+    return marker
+
+
+def _bounded_attribution(*, value: str | None, max_bytes: int) -> str | None:
+    """Bound transport attribution while preserving a recognizable prefix.
+
+    Returns:
+        str | None: The original value or its bounded prefix.
+    """
+    if value is None or len(json.dumps(value).encode("utf-8")) <= max_bytes:
+        return value
+    low = 0
+    high = len(value)
+    while low < high:
+        prefix_length = (low + high + 1) // 2
+        candidate = f"{value[:prefix_length]}..."
+        if len(json.dumps(candidate).encode("utf-8")) <= max_bytes:
+            low = prefix_length
+        else:
+            high = prefix_length - 1
+    return f"{value[:low]}..."
+
+
+def _serialize_capped_result(
+    *,
+    config: pytest.Config,
+    result: Result,
+    nodeid: str,
+) -> dict[str, Any]:
+    """Serialize one Result, replacing only that Result when oversized.
+
+    Returns:
+        dict[str, Any]: Full Result data or a bounded truncation marker.
+    """
+    data = _serialize_result(result=result, nodeid=nodeid)
+    size_bytes = _serialized_size(data=data)
+    limit_bytes = _size_limit(config=config)
+    try:
+        _enforce_result_size(
+            size_bytes=size_bytes,
+            limit_bytes=limit_bytes,
+            nodeid=nodeid,
+        )
+    except SizeLimitError as exc:
+        logger.warning("%s", exc)
+        return _truncated_result_data(
+            result=result,
+            nodeid=nodeid,
+            size_bytes=size_bytes,
+            limit_bytes=limit_bytes,
+        )
+    return data
+
+
+def serialize_report_data(
+    *,
+    config: pytest.Config,
+    nodeid: str,
+    results: list[Result],
+) -> dict[str, Any]:
+    """Serialize call-phase Results into an execnet-safe report envelope.
+
+    Returns:
+        dict[str, Any]: JSON-safe report envelope.
+    """
+    return {
+        "schema": SCHEMA_VERSION,
+        "nodeid": nodeid,
+        "results": [
+            _serialize_capped_result(
+                config=config,
+                result=result,
+                nodeid=nodeid,
+            )
+            for result in results
+        ],
+    }
+
+
+def attach_report_results(
+    *,
+    config: pytest.Config,
+    report: pytest.TestReport,
+    results: list[Result],
+) -> int:
+    """Attach serialized Results to a call-phase worker report.
+
+    Returns:
+        int: Number of Result representations attached.
+    """
+    if not results:
+        return 0
+    data = serialize_report_data(
+        config=config,
+        nodeid=report.nodeid,
+        results=results,
+    )
+    setattr(report, REPORT_RESULTS_ATTR, data)
+    return len(results)
+
+
+def serialize_worker_data(
+    *,
+    session: RampartSession,
+    streamed_result_count: int,
+) -> dict[str, Any]:
+    """Serialize slim session-level worker data for the controller.
+
+    Results are deliberately absent because call-phase reports are the
+    sole Result transport. Workeroutput retains trial specs and the
+    expected streamed Result count for completeness reconciliation.
 
     Args:
         session (RampartSession): The worker's session state.
+        streamed_result_count (int): Result representations attached to
+            reports by this worker.
 
     Returns:
         dict[str, Any]: A JSON-safe payload ready to write to
             ``config.workeroutput``.
     """
-    serialized: dict[str, list[dict[str, Any]]] = {}
-    for nodeid, results in session.results_by_nodeid.items():
-        serialized[nodeid] = [
-            _serialize_result(result=r, nodeid=nodeid) for r in results
-        ]
     return {
         "schema": SCHEMA_VERSION,
-        "results_by_nodeid": serialized,
+        _STREAMED_RESULT_COUNT: streamed_result_count,
         "trial_specs": [
             {
                 "clone_nodeid": clone_nodeid,
@@ -944,48 +1165,59 @@ def _deserialize_result(*, data: object) -> Result:
     )
 
 
-def deserialize_worker_data(*, data: object) -> dict[str, list[Result]]:
-    """Deserialize a worker payload back into a ``results_by_nodeid`` mapping.
+def deserialize_report_data(
+    *,
+    data: object,
+    report_nodeid: str,
+) -> tuple[dict[str, list[Result]], bool]:
+    """Deserialize one call-phase report envelope.
 
     Performs strict schema validation: missing ``schema`` key, unknown
     versions, and malformed enum values all raise ``WorkerOutputError``
-    (or subclass). Caller should catch and mark the run incomplete
-    rather than letting the exception propagate to pytest.
+    (or subclass). The report nodeid and envelope nodeid must agree.
 
     Each result's ``metadata["_pytest_nodeid"]`` and
     ``metadata["_rampart_result_index"]`` are set authoritatively from the
-    outer mapping key and list position so cross-worker ordering is total
+    envelope nodeid and list position so cross-worker ordering is total
     and independent of any (untrusted) serialized values.
 
     Args:
-        data (object): The deserialized JSON object from
-            ``node.workeroutput``.
+        data (object): The deserialized private TestReport attribute.
+        report_nodeid (str): The nodeid from the owning TestReport.
 
     Returns:
-        dict[str, list[Result]]: Results grouped by nodeid.
+        tuple[dict[str, list[Result]], bool]: Results grouped by nodeid
+            and whether any Result is a truncation marker.
 
     Raises:
         SchemaVersionError: Missing or unknown schema version.
         WorkerOutputError: Malformed payload (type errors, bad enums).
     """
     typed = _validate_schema(data=data)
-    raw_results = typed.get("results_by_nodeid", {})
-    if not isinstance(raw_results, dict):
-        msg = f"Expected dict for results_by_nodeid, got {type(raw_results).__name__}."
+    nodeid = typed.get("nodeid")
+    if not isinstance(nodeid, str) or not nodeid:
+        msg = "Streamed report envelope has an invalid 'nodeid'."
         raise WorkerOutputError(msg)
-    out: dict[str, list[Result]] = {}
-    for nodeid, results_data in cast("dict[Any, Any]", raw_results).items():
-        if not isinstance(results_data, list):
-            continue
-        nodeid_str = str(nodeid)
-        deserialized: list[Result] = []
-        for index, raw_result in enumerate(cast("list[Any]", results_data)):
-            result = _deserialize_result(data=raw_result)
-            result.metadata["_pytest_nodeid"] = nodeid_str
-            result.metadata["_rampart_result_index"] = index
-            deserialized.append(result)
-        out[nodeid_str] = deserialized
-    return out
+    if nodeid != report_nodeid:
+        msg = (
+            f"Streamed envelope nodeid {nodeid!r} does not match "
+            f"TestReport nodeid {report_nodeid!r}."
+        )
+        raise WorkerOutputError(msg)
+    raw_results = typed.get("results")
+    if not isinstance(raw_results, list):
+        msg = f"Expected list for results, got {type(raw_results).__name__}."
+        raise WorkerOutputError(msg)
+    deserialized: list[Result] = []
+    truncated = False
+    for index, raw_result in enumerate(cast("list[Any]", raw_results)):
+        result = _deserialize_result(data=raw_result)
+        result.metadata["_pytest_nodeid"] = nodeid
+        result.metadata["_rampart_result_index"] = index
+        deserialized.append(result)
+        if isinstance(raw_result, dict) and raw_result.get(_TRUNCATED_MARKER) is True:
+            truncated = True
+    return {nodeid: deserialized}, truncated
 
 
 def deserialize_trial_specs(*, data: object) -> dict[str, TrialSpec]:
@@ -1043,8 +1275,13 @@ def deserialize_trial_specs(*, data: object) -> dict[str, TrialSpec]:
     return out
 
 
-def finalize_worker(*, config: pytest.Config, session: RampartSession) -> None:
-    """Serialize the worker's session state into ``config.workeroutput``.
+def finalize_worker(
+    *,
+    config: pytest.Config,
+    session: RampartSession,
+    streamed_result_count: int,
+) -> None:
+    """Serialize slim worker session state into ``config.workeroutput``.
 
     Called from ``pytest_sessionfinish`` on each xdist worker. The
     worker skips sink emission entirely; the controller is responsible
@@ -1053,38 +1290,19 @@ def finalize_worker(*, config: pytest.Config, session: RampartSession) -> None:
     Args:
         config (pytest.Config): The pytest configuration object.
         session (RampartSession): The worker's session state.
-
-    Raises:
-        SizeLimitError: If the serialized payload exceeds the
-            configured cap. The truncation marker is still written to
-            ``workeroutput`` before the exception is raised so the
-            controller can record the run as incomplete.
+        streamed_result_count (int): Number of Result representations
+            attached to test reports by this worker.
     """
     if not is_xdist_worker(config=config):
         return
-    payload = serialize_worker_data(session=session)
-    encoded = json.dumps(payload, default=str)
-    size = len(encoded.encode("utf-8"))
-    limit = _size_limit(config=config)
     workeroutput = cast(
         "dict[str, Any]",
         config.workeroutput,  # ty: ignore[unresolved-attribute]
     )
-    if size > limit:
-        workeroutput[WORKEROUTPUT_KEY] = {
-            "schema": SCHEMA_VERSION,
-            _TRUNCATED_MARKER: True,
-            "size_bytes": size,
-            "limit_bytes": limit,
-        }
-        msg = (
-            f"Worker payload size {size} bytes exceeds cap of {limit}; "
-            f"truncated. Increase --{SIZE_LIMIT_OPTION.replace('_', '-')} "
-            f"(or the {SIZE_LIMIT_OPTION} ini option) to raise the cap."
-        )
-        raise SizeLimitError(msg)
-    logger.debug("Worker payload size: %d bytes", size)
-    workeroutput[WORKEROUTPUT_KEY] = payload
+    workeroutput[WORKEROUTPUT_KEY] = serialize_worker_data(
+        session=session,
+        streamed_result_count=streamed_result_count,
+    )
 
 
 def _safe_deserialize_trial_specs(
@@ -1136,13 +1354,88 @@ def _tag_source_worker(
             result.metadata["_rampart_source_worker"] = worker_id_str
 
 
+def get_worker_id(node: object) -> str:
+    """Return xdist's stable identifier for a worker node."""
+    gateway = getattr(node, "gateway", None)
+    return str(getattr(gateway, "id", node)) if gateway else str(node)
+
+
+def _report_worker_id(*, report: pytest.TestReport) -> str:
+    """Return the source worker identifier carried by xdist.
+
+    Returns:
+        str: Stable xdist worker identifier.
+
+    Raises:
+        WorkerOutputError: If the report has no source worker.
+    """
+    worker_id = getattr(report, "worker_id", None)
+    if isinstance(worker_id, str) and worker_id:
+        return worker_id
+    node = getattr(report, "node", None)
+    if node is not None:
+        return get_worker_id(node)
+    msg = f"Streamed report for {report.nodeid!r} has no source worker identifier."
+    raise WorkerOutputError(msg)
+
+
+def merge_report_results(
+    *,
+    session: RampartSession,
+    report: pytest.TestReport,
+) -> tuple[str, int] | None:
+    """Validate and incrementally merge one streamed report envelope.
+
+    Returns:
+        tuple[str, int] | None: Source worker and merged Result count,
+            or None when the report carries no RAMPART envelope.
+    """
+    payload = getattr(report, REPORT_RESULTS_ATTR, None)
+    if payload is None:
+        return None
+    worker_id = _report_worker_id(report=report)
+    results_by_nodeid, truncated = deserialize_report_data(
+        data=payload,
+        report_nodeid=report.nodeid,
+    )
+    _tag_source_worker(
+        results_by_nodeid=results_by_nodeid,
+        worker_id_str=worker_id,
+    )
+    session.merge_worker_results(results_by_nodeid=results_by_nodeid)
+    result_count = sum(len(results) for results in results_by_nodeid.values())
+    if truncated:
+        session.mark_incomplete(
+            reason=f"worker {worker_id} streamed a truncated Result (size cap)",
+        )
+    return worker_id, result_count
+
+
+def _deserialize_streamed_result_count(*, payload: object) -> int:
+    """Read the expected Result count from slim workeroutput.
+
+    Returns:
+        int: Expected streamed Result count.
+
+    Raises:
+        WorkerOutputError: If the count is missing or invalid.
+    """
+    typed = _validate_schema(data=payload)
+    raw_count = typed.get(_STREAMED_RESULT_COUNT)
+    if type(raw_count) is not int or raw_count < 0:
+        msg = "Worker payload missing a valid non-negative streamed_result_count."
+        raise WorkerOutputError(msg)
+    return raw_count
+
+
 def handle_testnodedown(
     *,
     session: RampartSession,
     node: object,
     error: object,
+    received_result_count: int,
 ) -> None:
-    """Merge a finished worker's results into the controller session.
+    """Reconcile a finished worker's streamed Result count.
 
     Called from ``pytest_testnodedown`` on the controller for each
     worker that completes. Failures (missing payload, deserialization
@@ -1153,9 +1446,9 @@ def handle_testnodedown(
         session (RampartSession): The controller's session state.
         node: The xdist node object (has ``workeroutput`` attribute).
         error: The shutdown error from xdist, or None on clean exit.
+        received_result_count (int): Results already merged from this worker.
     """
-    worker_id = getattr(node, "gateway", None)
-    worker_id_str = str(getattr(worker_id, "id", node)) if worker_id else str(node)
+    worker_id_str = get_worker_id(node)
     if error is not None:
         logger.warning(
             "Worker %s reported shutdown error; report will be incomplete: %s",
@@ -1180,46 +1473,36 @@ def handle_testnodedown(
         )
         session.mark_incomplete(reason=f"worker {worker_id_str} missing RAMPART output")
         return
-    typed_payload_dict: dict[str, Any] | None = (
-        cast("dict[str, Any]", payload) if isinstance(payload, dict) else None
-    )
-    if typed_payload_dict is not None and typed_payload_dict.get(_TRUNCATED_MARKER):
-        logger.error(
-            "Worker %s payload was truncated due to size cap; "
-            "report will be incomplete.",
-            worker_id_str,
-        )
-        session.mark_incomplete(
-            reason=f"worker {worker_id_str} payload truncated (size cap)",
-        )
-        return
-    try:
-        results_by_nodeid = deserialize_worker_data(data=cast("object", payload))
-    except WorkerOutputError as exc:
-        logger.exception(
-            "Failed to deserialize worker %s output; report will be incomplete.",
-            worker_id_str,
-        )
-        session.mark_incomplete(
-            reason=f"worker {worker_id_str} deserialization failed: {exc}",
-        )
-        return
     trial_specs = _safe_deserialize_trial_specs(
         payload=cast("object", payload),
         worker_id_str=worker_id_str,
     )
-    _tag_source_worker(
-        results_by_nodeid=results_by_nodeid,
-        worker_id_str=worker_id_str,
-    )
-    session.merge_worker_results(results_by_nodeid=results_by_nodeid)
     if trial_specs:
         session.merge_trial_specs(trial_specs=trial_specs)
-    logger.info(
-        "Merged %d result group(s) from worker %s.",
-        len(results_by_nodeid),
-        worker_id_str,
-    )
+    try:
+        expected_result_count = _deserialize_streamed_result_count(payload=payload)
+    except WorkerOutputError:
+        logger.exception(
+            "Worker %s streamed Result count is invalid; report will be incomplete.",
+            worker_id_str,
+        )
+        session.mark_incomplete(
+            reason=f"worker {worker_id_str} missing streamed Result count",
+        )
+        return
+    if expected_result_count != received_result_count:
+        logger.error(
+            "Worker %s streamed Result count mismatch: expected %d, received %d.",
+            worker_id_str,
+            expected_result_count,
+            received_result_count,
+        )
+        session.mark_incomplete(
+            reason=(
+                f"worker {worker_id_str} streamed Result count mismatch "
+                f"(expected {expected_result_count}, received {received_result_count})"
+            ),
+        )
 
 
 def discover_sinks_from_conftest(*, config: pytest.Config) -> list[ReportSink]:

--- a/rampart/pytest_plugin/_xdist.py
+++ b/rampart/pytest_plugin/_xdist.py
@@ -643,7 +643,7 @@ def _bounded_attribution(*, value: str | None, max_bytes: int) -> str | None:
 
 def _serialize_capped_result(
     *,
-    config: pytest.Config,
+    limit_bytes: int,
     result: Result,
     nodeid: str,
 ) -> dict[str, Any]:
@@ -654,7 +654,6 @@ def _serialize_capped_result(
     """
     data = _serialize_result(result=result, nodeid=nodeid)
     size_bytes = _serialized_size(data=data)
-    limit_bytes = _size_limit(config=config)
     try:
         _enforce_result_size(
             size_bytes=size_bytes,
@@ -683,12 +682,13 @@ def serialize_report_data(
     Returns:
         dict[str, Any]: JSON-safe report envelope.
     """
+    limit_bytes = _size_limit(config=config)
     return {
         "schema": SCHEMA_VERSION,
         "nodeid": nodeid,
         "results": [
             _serialize_capped_result(
-                config=config,
+                limit_bytes=limit_bytes,
                 result=result,
                 nodeid=nodeid,
             )

--- a/rampart/pytest_plugin/_xdist.py
+++ b/rampart/pytest_plugin/_xdist.py
@@ -60,7 +60,7 @@ SCHEMA_VERSION: str = "rampart.xdist.v2"
 WORKEROUTPUT_KEY: str = "rampart_xdist_v2"
 REPORT_RESULTS_ATTR: str = "_rampart_results"
 SIZE_LIMIT_OPTION: str = "rampart_xdist_max_bytes"
-DEFAULT_SIZE_LIMIT_BYTES: int = 64 * 1024 * 1024
+DEFAULT_SIZE_LIMIT_BYTES: int = 16 * 1024 * 1024
 MIN_RESULT_SIZE_LIMIT_BYTES: int = 4 * 1024
 MAX_METADATA_DEPTH: int = 6
 

--- a/rampart/pytest_plugin/plugin.py
+++ b/rampart/pytest_plugin/plugin.py
@@ -43,18 +43,21 @@ from rampart.pytest_plugin._collection import (
     deactivate_collector,
     get_active_collector,
 )
-from rampart.pytest_plugin._session import RampartSession
+from rampart.pytest_plugin._session import RampartSession, tag_collected_results
 from rampart.pytest_plugin._xdist import (
     DEFAULT_SIZE_LIMIT_BYTES,
     SIZE_LIMIT_OPTION,
-    SizeLimitError,
+    WorkerOutputError,
+    attach_report_results,
     discover_sinks_from_conftest,
     finalize_worker,
     get_dist_mode,
     get_worker_count,
+    get_worker_id,
     handle_testnodedown,
     is_xdist_controller,
     is_xdist_worker,
+    merge_report_results,
 )
 from rampart.reporting.sink import ReportSink
 
@@ -70,6 +73,7 @@ __all__ = [
     "pytest_addoption",
     "pytest_collection_modifyitems",
     "pytest_configure",
+    "pytest_runtest_logreport",
     "pytest_runtest_makereport",
     "pytest_sessionfinish",
     "pytest_terminal_summary",
@@ -80,6 +84,8 @@ __all__ = [
 # Config-scoped stash keys: one entry per pytest session.
 _rampart_key = pytest.StashKey[RampartSession]()
 _session_start_key = pytest.StashKey[float]()
+_streamed_result_count_key = pytest.StashKey[int]()
+_received_result_counts_key = pytest.StashKey[dict[str, int]]()
 
 # Item-scoped stash key: a per-test snapshot consumed by xdist streaming.
 _call_results_key = pytest.StashKey[list[Result]]()
@@ -185,14 +191,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         type=int,
         default=None,
         help=(
-            "Maximum size in bytes of a worker's serialized result payload "
+            "Maximum size in bytes of each serialized Result "
             f"under pytest-xdist (default: {DEFAULT_SIZE_LIMIT_BYTES})."
         ),
     )
     parser.addini(
         SIZE_LIMIT_OPTION,
         help=(
-            "Maximum size in bytes of a worker's serialized result payload "
+            "Maximum size in bytes of each serialized Result "
             f"under pytest-xdist (default: {DEFAULT_SIZE_LIMIT_BYTES})."
         ),
         default=None,
@@ -493,7 +499,58 @@ def pytest_runtest_makereport(
         collector = get_active_collector()
         if collector is not None:
             item.stash[_call_results_key] = collector.results
+            results = tag_collected_results(
+                node=item,
+                results=item.stash[_call_results_key],
+            )
+            emitted_count = attach_report_results(
+                config=item.config,
+                report=report,
+                results=results,
+            )
+            current_count = item.config.stash.get(_streamed_result_count_key, 0)
+            item.config.stash[_streamed_result_count_key] = (
+                current_count + emitted_count
+            )
     return report
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Merge a streamed xdist Result envelope on the controller.
+
+    Malformed envelopes mark the run incomplete instead of aborting
+    pytest, matching the workeroutput trust-boundary convention.
+
+    Args:
+        report (pytest.TestReport): A setup, call, or teardown report.
+    """
+    node = getattr(report, "node", None)
+    config = getattr(node, "config", None)
+    if config is None or not is_xdist_controller(config=config):
+        return
+    rampart_session = config.stash.get(_rampart_key, None)
+    if rampart_session is None:
+        return
+    try:
+        merged = merge_report_results(session=rampart_session, report=report)
+    except WorkerOutputError as exc:
+        worker_id = get_worker_id(node)
+        logger.exception(
+            "Failed to merge streamed Result report from worker %s.",
+            worker_id,
+        )
+        rampart_session.mark_incomplete(
+            reason=f"worker {worker_id} streamed report invalid: {exc}",
+        )
+        return
+    if merged is None:
+        return
+    worker_id, result_count = merged
+    received_counts = config.stash.get(_received_result_counts_key, None)
+    if received_counts is None:
+        received_counts = {}
+        config.stash[_received_result_counts_key] = received_counts
+    received_counts[worker_id] = received_counts.get(worker_id, 0) + result_count
 
 
 def _has_sink_hook_impl(*, config: pytest.Config) -> bool:
@@ -733,8 +790,8 @@ def pytest_sessionfinish(
 
     Dispatches between three modes:
 
-    - xdist worker: serialize results to ``config.workeroutput`` and
-      skip sink emission (the controller emits the unified report).
+    - xdist worker: write slim session metadata to ``config.workeroutput``
+      and skip sink emission (Results already streamed on test reports).
     - xdist controller: trials already aggregated against the merged
       ``_results_by_nodeid``; resolve sinks via the
       ``pytest_rampart_sinks`` hook (falling back to conftest discovery),
@@ -759,10 +816,15 @@ def pytest_sessionfinish(
         rampart_session.set_duration(duration_seconds=time.monotonic() - start_time)
 
     if is_xdist_worker(config=session.config):
-        try:
-            finalize_worker(config=session.config, session=rampart_session)
-        except SizeLimitError as exc:
-            logger.warning("%s", exc)
+        streamed_result_count = session.config.stash.get(
+            _streamed_result_count_key,
+            0,
+        )
+        finalize_worker(
+            config=session.config,
+            session=rampart_session,
+            streamed_result_count=streamed_result_count,
+        )
         return
 
     _aggregate_trial_results(rampart_session=rampart_session)
@@ -787,7 +849,7 @@ def pytest_sessionfinish(
 
 @pytest.hookimpl(optionalhook=True)
 def pytest_testnodedown(node: object, error: object) -> None:
-    """Merge a finished xdist worker's results into the controller session.
+    """Reconcile a finished xdist worker's streamed Result count.
 
     Thin delegate to ``_xdist.handle_testnodedown`` so plugin.py stays
     focused on hook registration. Registered as ``optionalhook`` so
@@ -804,7 +866,14 @@ def pytest_testnodedown(node: object, error: object) -> None:
     rampart_session = config.stash.get(_rampart_key, None)
     if rampart_session is None:
         return
-    handle_testnodedown(session=rampart_session, node=node, error=error)
+    received_counts = config.stash.get(_received_result_counts_key, {})
+    worker_id = get_worker_id(node)
+    handle_testnodedown(
+        session=rampart_session,
+        node=node,
+        error=error,
+        received_result_count=received_counts.get(worker_id, 0),
+    )
 
 
 def _record_xdist_metadata(

--- a/rampart/pytest_plugin/plugin.py
+++ b/rampart/pytest_plugin/plugin.py
@@ -471,13 +471,12 @@ def pytest_runtest_makereport(
     item: pytest.Item,
     call: pytest.CallInfo[None],
 ) -> Generator[None, pytest.TestReport, pytest.TestReport]:
-    """Snapshot the active collector's results at the call phase.
+    """Snapshot the active collector's results for xdist transport.
 
-    On xdist workers, copies the per-test results onto the item stash
-    while the collector is still active — before the autouse fixture's
-    teardown drains and deactivates it. Downstream xdist streaming reads
-    this snapshot to deliver results per test rather than in a single
-    end-of-worker batch.
+    On xdist workers, the call report carries all Results recorded through
+    successful setup and call. If setup fails or skips after recording Results,
+    its report carries the snapshot because pytest will not produce a call report.
+    Teardown-only Results remain outside the transport boundary.
 
     Restricted to worker processes: single-process and controller runs
     never consume the snapshot, so skipping it there keeps those paths
@@ -495,23 +494,26 @@ def pytest_runtest_makereport(
             unchanged report produced by downstream hookimpls.
     """
     report = yield
-    if call.when == "call" and is_xdist_worker(config=item.config):
-        collector = get_active_collector()
-        if collector is not None:
-            item.stash[_call_results_key] = collector.results
-            results = tag_collected_results(
-                node=item,
-                results=item.stash[_call_results_key],
-            )
-            emitted_count = attach_report_results(
-                config=item.config,
-                report=report,
-                results=results,
-            )
-            current_count = item.config.stash.get(_streamed_result_count_key, 0)
-            item.config.stash[_streamed_result_count_key] = (
-                current_count + emitted_count
-            )
+    if call.when not in {"setup", "call"} or not is_xdist_worker(config=item.config):
+        return report
+    collector = get_active_collector()
+    if collector is None:
+        return report
+    snapshot = collector.results
+    if call.when == "setup" and (report.passed or not snapshot):
+        return report
+    item.stash[_call_results_key] = snapshot
+    results = tag_collected_results(
+        node=item,
+        results=item.stash[_call_results_key],
+    )
+    emitted_count = attach_report_results(
+        config=item.config,
+        report=report,
+        results=results,
+    )
+    current_count = item.config.stash.get(_streamed_result_count_key, 0)
+    item.config.stash[_streamed_result_count_key] = current_count + emitted_count
     return report
 
 

--- a/tests/unit/pytest_plugin/test_plugin.py
+++ b/tests/unit/pytest_plugin/test_plugin.py
@@ -152,6 +152,21 @@ class TestRampartSession:
         assert report.total_runs == 1
         assert report.passed == 1
 
+    def test_absorb_uses_parameterized_item_display_name(self) -> None:
+        session = RampartSession()
+        collector = ResultCollector()
+        collector.record(
+            result=Result(status=SafetyStatus.SAFE, summary="ok"),
+        )
+        node = MagicMock()
+        node.nodeid = "test_file.py::test_absorb[raw-id]"
+        node.name = "test_absorb[display-id]"
+
+        session.absorb(node=node, collector=collector)
+
+        result = session.build_report().results[0]
+        assert result.metadata["_pytest_test_name"] == "test_absorb[display-id]"
+
     def test_has_results_false_when_empty(self) -> None:
         session = RampartSession()
         assert not session.has_results

--- a/tests/unit/pytest_plugin/test_plugin.py
+++ b/tests/unit/pytest_plugin/test_plugin.py
@@ -21,19 +21,24 @@ from rampart.pytest_plugin._collection import (
     deactivate_collector,
 )
 from rampart.pytest_plugin._session import RampartSession
+from rampart.pytest_plugin._xdist import REPORT_RESULTS_ATTR, serialize_report_data
 from rampart.pytest_plugin.plugin import (
     _call_results_key,
     _emit_sinks,
     _enforce_incomplete_exit_status,
     _evaluate_gates,
     _has_sink_hook_impl,
+    _rampart_key,
+    _received_result_counts_key,
     _resolve_hook_sinks,
     _resolve_trial_n,
     _sanitize_for_terminal,
+    _streamed_result_count_key,
     _write_result_line,
     _write_trial_group_lines,
     pytest_collection_modifyitems,
     pytest_configure,
+    pytest_runtest_logreport,
     pytest_runtest_makereport,
     pytest_sessionfinish,
     pytest_terminal_summary,
@@ -993,10 +998,20 @@ def _make_reporting_item(*, worker: bool = True) -> Any:
     """
     item = MagicMock()
     item.stash = pytest.Stash()
+    item.nodeid = "test_plugin.py::test_stream"
+    item.get_closest_marker.return_value = None
+    config_kwargs = {
+        "stash": pytest.Stash(),
+        "getoption": lambda _name, default=None: default,
+        "getini": lambda _name: None,
+    }
     if worker:
-        item.config = SimpleNamespace(workerinput={"workerid": "gw0"})
+        item.config = SimpleNamespace(
+            workerinput={"workerid": "gw0"},
+            **config_kwargs,
+        )
     else:
-        item.config = SimpleNamespace()
+        item.config = SimpleNamespace(**config_kwargs)
     return item
 
 
@@ -1004,7 +1019,14 @@ def _drive_makereport(*, item: Any, when: str, report: Any = None) -> Any:
     """Drive the makereport wrapper generator and return its result."""
     call = MagicMock()
     call.when = when
-    sent = report if report is not None else MagicMock()
+    sent = cast(
+        "pytest.TestReport",
+        (
+            report
+            if report is not None
+            else SimpleNamespace(nodeid="test_plugin.py::test_stream")
+        ),
+    )
     gen = pytest_runtest_makereport(
         item=cast("pytest.Item", item),
         call=cast("pytest.CallInfo[None]", call),
@@ -1033,6 +1055,7 @@ class TestPytestRuntestMakereport:
         snapshot = item.stash[_call_results_key]
         assert len(snapshot) == 1
         assert snapshot[0].summary == "captured"
+        assert item.config.stash[_streamed_result_count_key] == 1
 
     def test_snapshots_empty_list_when_no_results(self) -> None:
         item = _make_reporting_item()
@@ -1044,6 +1067,7 @@ class TestPytestRuntestMakereport:
             deactivate_collector(token)
 
         assert item.stash[_call_results_key] == []
+        assert item.config.stash[_streamed_result_count_key] == 0
 
     def test_no_snapshot_at_setup_phase(self) -> None:
         item = _make_reporting_item()
@@ -1056,6 +1080,19 @@ class TestPytestRuntestMakereport:
             deactivate_collector(token)
 
         assert _call_results_key not in item.stash
+
+    def test_no_transport_at_teardown_phase(self) -> None:
+        item = _make_reporting_item()
+        collector = ResultCollector()
+        collector.record(result=_make_result(summary="teardown-only"))
+        token = activate_collector(collector)
+        try:
+            report = _drive_makereport(item=item, when="teardown")
+        finally:
+            deactivate_collector(token)
+
+        assert _call_results_key not in item.stash
+        assert not hasattr(report, REPORT_RESULTS_ATTR)
 
     def test_no_snapshot_when_no_collector_active(self) -> None:
         item = _make_reporting_item()
@@ -1086,3 +1123,65 @@ class TestPytestRuntestMakereport:
         returned = _drive_makereport(item=item, when="call", report=report)
 
         assert returned is report
+
+    def test_report_envelope_contains_call_snapshot_only(self) -> None:
+        item = _make_reporting_item()
+        collector = ResultCollector()
+        collector.record(result=_make_result(summary="call"))
+        token = activate_collector(collector)
+        try:
+            report = _drive_makereport(item=item, when="call")
+            collector.record(result=_make_result(summary="teardown"))
+        finally:
+            deactivate_collector(token)
+
+        envelope = getattr(report, REPORT_RESULTS_ATTR)
+        assert envelope["nodeid"] == item.nodeid
+        assert len(envelope["results"]) == 1
+        assert envelope["results"][0]["summary"] == "call"
+
+
+def _make_controller_report(*, payload: object) -> tuple[Any, RampartSession]:
+    config = SimpleNamespace(
+        option=SimpleNamespace(dist="load", numprocesses=2, tx=None),
+        stash=pytest.Stash(),
+    )
+    rampart_session = RampartSession()
+    config.stash[_rampart_key] = rampart_session
+    node = SimpleNamespace(
+        config=config,
+        gateway=SimpleNamespace(id="gw0"),
+    )
+    report = SimpleNamespace(
+        node=node,
+        nodeid="test_plugin.py::test_stream",
+        worker_id="gw0",
+    )
+    setattr(report, REPORT_RESULTS_ATTR, payload)
+    return report, rampart_session
+
+
+class TestPytestRuntestLogreport:
+    def test_controller_incrementally_merges_and_counts_results(self) -> None:
+        nodeid = "test_plugin.py::test_stream"
+        payload = serialize_report_data(
+            config=_make_reporting_item().config,
+            nodeid=nodeid,
+            results=[_make_result(summary="one"), _make_result(summary="two")],
+        )
+        report, rampart_session = _make_controller_report(payload=payload)
+        pytest_runtest_logreport(cast("pytest.TestReport", report))
+        counts = report.node.config.stash[_received_result_counts_key]
+        assert [result.summary for result in rampart_session._results] == ["one", "two"]
+        assert counts == {"gw0": 2}
+        assert {
+            result.metadata["_rampart_source_worker"]
+            for result in rampart_session._results
+        } == {"gw0"}
+
+    def test_malformed_envelope_marks_run_incomplete(self) -> None:
+        report, rampart_session = _make_controller_report(
+            payload={"schema": "wrong"},
+        )
+        pytest_runtest_logreport(cast("pytest.TestReport", report))
+        assert rampart_session.is_incomplete is True

--- a/tests/unit/pytest_plugin/test_plugin.py
+++ b/tests/unit/pytest_plugin/test_plugin.py
@@ -1014,6 +1014,7 @@ def _make_reporting_item(*, worker: bool = True) -> Any:
     item = MagicMock()
     item.stash = pytest.Stash()
     item.nodeid = "test_plugin.py::test_stream"
+    item.name = "test_stream"
     item.get_closest_marker.return_value = None
     config_kwargs = {
         "stash": pytest.Stash(),
@@ -1030,7 +1031,13 @@ def _make_reporting_item(*, worker: bool = True) -> Any:
     return item
 
 
-def _drive_makereport(*, item: Any, when: str, report: Any = None) -> Any:
+def _drive_makereport(
+    *,
+    item: Any,
+    when: str,
+    outcome: str = "passed",
+    report: Any = None,
+) -> Any:
     """Drive the makereport wrapper generator and return its result."""
     call = MagicMock()
     call.when = when
@@ -1039,7 +1046,10 @@ def _drive_makereport(*, item: Any, when: str, report: Any = None) -> Any:
         (
             report
             if report is not None
-            else SimpleNamespace(nodeid="test_plugin.py::test_stream")
+            else SimpleNamespace(
+                nodeid="test_plugin.py::test_stream",
+                passed=outcome == "passed",
+            )
         ),
     )
     gen = pytest_runtest_makereport(
@@ -1084,17 +1094,39 @@ class TestPytestRuntestMakereport:
         assert item.stash[_call_results_key] == []
         assert item.config.stash[_streamed_result_count_key] == 0
 
-    def test_no_snapshot_at_setup_phase(self) -> None:
+    @pytest.mark.parametrize("outcome", ["failed", "skipped"])
+    def test_nonpassing_setup_streams_collected_results(self, outcome: str) -> None:
         item = _make_reporting_item()
         collector = ResultCollector()
-        collector.record(result=_make_result())
+        collector.record(result=_make_result(summary=outcome))
         token = activate_collector(collector)
         try:
-            _drive_makereport(item=item, when="setup")
+            report = _drive_makereport(item=item, when="setup", outcome=outcome)
         finally:
             deactivate_collector(token)
 
-        assert _call_results_key not in item.stash
+        envelope = getattr(report, REPORT_RESULTS_ATTR)
+        assert envelope["results"][0]["summary"] == outcome
+        assert item.config.stash[_streamed_result_count_key] == 1
+
+    def test_successful_setup_defers_results_to_call(self) -> None:
+        item = _make_reporting_item()
+        collector = ResultCollector()
+        collector.record(result=_make_result(summary="setup"))
+        token = activate_collector(collector)
+        try:
+            setup_report = _drive_makereport(item=item, when="setup")
+            collector.record(result=_make_result(summary="call"))
+            call_report = _drive_makereport(item=item, when="call")
+        finally:
+            deactivate_collector(token)
+
+        assert not hasattr(setup_report, REPORT_RESULTS_ATTR)
+        assert [
+            result["summary"]
+            for result in getattr(call_report, REPORT_RESULTS_ATTR)["results"]
+        ] == ["setup", "call"]
+        assert item.config.stash[_streamed_result_count_key] == 2
 
     def test_no_transport_at_teardown_phase(self) -> None:
         item = _make_reporting_item()

--- a/tests/unit/pytest_plugin/test_xdist.py
+++ b/tests/unit/pytest_plugin/test_xdist.py
@@ -1300,8 +1300,8 @@ class TestReportTestRunMetadata:
 
 
 class TestConstants:
-    def test_default_size_limit_is_64mb(self) -> None:
-        assert DEFAULT_SIZE_LIMIT_BYTES == 64 * 1024 * 1024
+    def test_default_size_limit_is_16mb(self) -> None:
+        assert DEFAULT_SIZE_LIMIT_BYTES == 16 * 1024 * 1024
 
     def test_schema_version_is_v2(self) -> None:
         assert SCHEMA_VERSION == "rampart.xdist.v2"

--- a/tests/unit/pytest_plugin/test_xdist.py
+++ b/tests/unit/pytest_plugin/test_xdist.py
@@ -1073,19 +1073,25 @@ class TestReportEnvelope:
         ]
         assert truncated is False
 
-    def test_oversized_result_is_localized_and_marks_incomplete(self) -> None:
-        payload = serialize_report_data(
-            config=_make_config(is_worker=True, max_bytes=1024),
-            nodeid="n",
-            results=[
-                _make_result(summary="normal"),
-                _make_result(
-                    summary="x" * 10_000,
-                    harm_category="custom-risk",
-                    metadata={"_pytest_test_name": "test_oversized"},
-                ),
-            ],
-        )
+    def test_oversized_result_is_localized_and_marks_incomplete(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        config = _make_config(is_worker=True, max_bytes=1024)
+        config.getoption = MagicMock(wraps=config.getoption)
+        with caplog.at_level(logging.WARNING):
+            payload = serialize_report_data(
+                config=config,
+                nodeid="n",
+                results=[
+                    _make_result(summary="normal"),
+                    _make_result(
+                        summary="x" * 10_000,
+                        harm_category="custom-risk",
+                        metadata={"_pytest_test_name": "test_oversized"},
+                    ),
+                ],
+            )
         report = MagicMock()
         report.nodeid = "n"
         report.worker_id = "gw0"
@@ -1103,6 +1109,11 @@ class TestReportEnvelope:
         assert len(json.dumps(marker).encode("utf-8")) <= MIN_RESULT_SIZE_LIMIT_BYTES
         assert marker["metadata"]["_rampart_limit_bytes"] == MIN_RESULT_SIZE_LIMIT_BYTES
         assert session.is_incomplete is True
+        config.getoption.assert_called_once_with(SIZE_LIMIT_OPTION, default=None)
+        assert (
+            sum("below the minimum" in record.getMessage() for record in caplog.records)
+            == 1
+        )
 
     @pytest.mark.parametrize(
         "escaped",

--- a/tests/unit/pytest_plugin/test_xdist.py
+++ b/tests/unit/pytest_plugin/test_xdist.py
@@ -35,16 +35,18 @@ from rampart.pytest_plugin._session import RampartSession, TrialSpec
 from rampart.pytest_plugin._xdist import (
     DEFAULT_SIZE_LIMIT_BYTES,
     MAX_METADATA_DEPTH,
+    MIN_RESULT_SIZE_LIMIT_BYTES,
+    REPORT_RESULTS_ATTR,
     SCHEMA_VERSION,
     SIZE_LIMIT_OPTION,
     WORKEROUTPUT_KEY,
     SchemaVersionError,
-    SizeLimitError,
     WorkerOutputError,
     _sanitize,
     _strip_ansi,
+    attach_report_results,
+    deserialize_report_data,
     deserialize_trial_specs,
-    deserialize_worker_data,
     discover_sinks_from_conftest,
     finalize_worker,
     get_dist_mode,
@@ -52,6 +54,8 @@ from rampart.pytest_plugin._xdist import (
     handle_testnodedown,
     is_xdist_controller,
     is_xdist_worker,
+    merge_report_results,
+    serialize_report_data,
     serialize_worker_data,
 )
 from rampart.reporting.sink import ReportSink, TestRunReport
@@ -154,6 +158,24 @@ def _make_session_with_results(
     for results in results_by_nodeid.values():
         session._results.extend(results)
     return session
+
+
+def _serialize_session_results(*, session: RampartSession) -> dict[str, Any]:
+    assert len(session.results_by_nodeid) == 1
+    nodeid, results = next(iter(session.results_by_nodeid.items()))
+    return serialize_report_data(
+        config=_make_config(is_worker=True),
+        nodeid=nodeid,
+        results=results,
+    )
+
+
+def _deserialize_report_results(*, data: object) -> dict[str, list[Result]]:
+    assert isinstance(data, dict)
+    nodeid = data.get("nodeid")
+    assert isinstance(nodeid, str)
+    results, _ = deserialize_report_data(data=data, report_nodeid=nodeid)
+    return results
 
 
 class TestDetection:
@@ -271,9 +293,9 @@ class TestSerializationRoundTrip:
         session = _make_session_with_results(
             results_by_nodeid={"test::a": [result]},
         )
-        payload = serialize_worker_data(session=session)
+        payload = _serialize_session_results(session=session)
         json.dumps(payload, default=str)
-        recovered = deserialize_worker_data(data=payload)
+        recovered = _deserialize_report_results(data=payload)
         assert "test::a" in recovered
         assert recovered["test::a"][0].safe is True
         assert recovered["test::a"][0].status is SafetyStatus.SAFE
@@ -285,8 +307,8 @@ class TestSerializationRoundTrip:
             session = _make_session_with_results(
                 results_by_nodeid={"n": [result]},
             )
-            payload = serialize_worker_data(session=session)
-            recovered = deserialize_worker_data(data=payload)
+            payload = _serialize_session_results(session=session)
+            recovered = _deserialize_report_results(data=payload)
             assert recovered["n"][0].status is status
 
     def test_observability_level_round_trip(self) -> None:
@@ -295,8 +317,8 @@ class TestSerializationRoundTrip:
             session = _make_session_with_results(
                 results_by_nodeid={"n": [result]},
             )
-            payload = serialize_worker_data(session=session)
-            recovered = deserialize_worker_data(data=payload)
+            payload = _serialize_session_results(session=session)
+            recovered = _deserialize_report_results(data=payload)
             assert recovered["n"][0].observability_level is level
 
     def test_harm_category_plain_string_round_trip(self) -> None:
@@ -304,8 +326,8 @@ class TestSerializationRoundTrip:
         session = _make_session_with_results(
             results_by_nodeid={"n": [result]},
         )
-        payload = serialize_worker_data(session=session)
-        recovered = deserialize_worker_data(data=payload)
+        payload = _serialize_session_results(session=session)
+        recovered = _deserialize_report_results(data=payload)
         assert recovered["n"][0].harm_category == "custom_product_risk"
 
     def test_turns_with_eval_result_round_trip(self) -> None:
@@ -320,8 +342,8 @@ class TestSerializationRoundTrip:
         session = _make_session_with_results(
             results_by_nodeid={"n": [result]},
         )
-        payload = serialize_worker_data(session=session)
-        recovered = deserialize_worker_data(data=payload)
+        payload = _serialize_session_results(session=session)
+        recovered = _deserialize_report_results(data=payload)
         assert recovered["n"][0].turns[0].eval_result is not None
         outcome = recovered["n"][0].turns[0].eval_result.outcome
         assert outcome is EvalOutcome.NOT_DETECTED
@@ -334,8 +356,8 @@ class TestSerializationRoundTrip:
         session = _make_session_with_results(
             results_by_nodeid={"n": [result]},
         )
-        payload = serialize_worker_data(session=session)
-        recovered = deserialize_worker_data(data=payload)
+        payload = _serialize_session_results(session=session)
+        recovered = _deserialize_report_results(data=payload)
         assert recovered["n"][0].turns[0].timestamp == when
 
     def test_injections_round_trip(self) -> None:
@@ -344,8 +366,8 @@ class TestSerializationRoundTrip:
         session = _make_session_with_results(
             results_by_nodeid={"n": [result]},
         )
-        payload = serialize_worker_data(session=session)
-        recovered = deserialize_worker_data(data=payload)
+        payload = _serialize_session_results(session=session)
+        recovered = _deserialize_report_results(data=payload)
         assert recovered["n"][0].injections[0].payload_id == "p1"
         assert recovered["n"][0].injections[0].surface_name == "OneDrive"
 
@@ -357,8 +379,8 @@ class TestSerializationRoundTrip:
         session = _make_session_with_results(
             results_by_nodeid={"n": [result]},
         )
-        payload = serialize_worker_data(session=session)
-        recovered = deserialize_worker_data(data=payload)
+        payload = _serialize_session_results(session=session)
+        recovered = _deserialize_report_results(data=payload)
         assert recovered["n"][0].turns[0].response.tool_calls[0].name == "send_email"
         assert recovered["n"][0].turns[0].response.tool_calls[0].arguments == {
             "to": "a@b.c",
@@ -372,8 +394,8 @@ class TestSerializationRoundTrip:
         session = _make_session_with_results(
             results_by_nodeid={"n": [result]},
         )
-        payload = serialize_worker_data(session=session)
-        recovered = deserialize_worker_data(data=payload)
+        payload = _serialize_session_results(session=session)
+        recovered = _deserialize_report_results(data=payload)
         assert recovered["n"][0].turns[0].response.side_effects[0].kind == "http"
 
     def test_metadata_round_trip(self) -> None:
@@ -381,8 +403,8 @@ class TestSerializationRoundTrip:
         session = _make_session_with_results(
             results_by_nodeid={"n": [result]},
         )
-        payload = serialize_worker_data(session=session)
-        recovered = deserialize_worker_data(data=payload)
+        payload = _serialize_session_results(session=session)
+        recovered = _deserialize_report_results(data=payload)
         assert recovered["n"][0].metadata["test_name"] == "t1"
         assert recovered["n"][0].metadata["tries"] == 3
 
@@ -390,95 +412,109 @@ class TestSerializationRoundTrip:
 class TestDeserializationValidation:
     def test_rejects_non_dict_payload(self) -> None:
         with pytest.raises(WorkerOutputError, match="Expected dict"):
-            deserialize_worker_data(data="not-a-dict")
+            deserialize_report_data(data="not-a-dict", report_nodeid="n")
 
     def test_rejects_missing_schema_key(self) -> None:
         with pytest.raises(SchemaVersionError, match="missing required 'schema'"):
-            deserialize_worker_data(data={"results_by_nodeid": {}})
+            deserialize_report_data(
+                data={"nodeid": "n", "results": []},
+                report_nodeid="n",
+            )
 
     def test_rejects_unknown_schema_version(self) -> None:
         payload: dict[str, Any] = {
             "schema": "rampart.xdist.v999",
-            "results_by_nodeid": {},
+            "nodeid": "n",
+            "results": [],
         }
         with pytest.raises(SchemaVersionError, match="does not match"):
-            deserialize_worker_data(data=payload)
+            deserialize_report_data(data=payload, report_nodeid="n")
+
+    def test_rejects_legacy_schema_version(self) -> None:
+        payload: dict[str, Any] = {
+            "schema": "rampart.xdist.v1",
+            "nodeid": "n",
+            "results": [],
+        }
+        with pytest.raises(SchemaVersionError, match="does not match"):
+            deserialize_report_data(data=payload, report_nodeid="n")
+
+    def test_rejects_nodeid_mismatch(self) -> None:
+        payload = {"schema": SCHEMA_VERSION, "nodeid": "other", "results": []}
+        with pytest.raises(WorkerOutputError, match="does not match"):
+            deserialize_report_data(data=payload, report_nodeid="n")
 
     def test_rejects_malformed_safety_status(self) -> None:
         payload: dict[str, Any] = {
             "schema": SCHEMA_VERSION,
-            "results_by_nodeid": {
-                "n": [
-                    {
-                        "safe": True,
-                        "status": "not-a-status",
-                        "summary": "x",
-                        "observability_level": "response_only",
-                    },
-                ],
-            },
+            "nodeid": "n",
+            "results": [
+                {
+                    "safe": True,
+                    "status": "not-a-status",
+                    "summary": "x",
+                    "observability_level": "response_only",
+                },
+            ],
         }
         with pytest.raises(WorkerOutputError, match="Unknown SafetyStatus"):
-            deserialize_worker_data(data=payload)
+            deserialize_report_data(data=payload, report_nodeid="n")
 
     def test_rejects_malformed_observability_level(self) -> None:
         payload: dict[str, Any] = {
             "schema": SCHEMA_VERSION,
-            "results_by_nodeid": {
-                "n": [
-                    {
-                        "safe": True,
-                        "status": "safe",
-                        "summary": "x",
-                        "observability_level": "not-a-level",
-                    },
-                ],
-            },
+            "nodeid": "n",
+            "results": [
+                {
+                    "safe": True,
+                    "status": "safe",
+                    "summary": "x",
+                    "observability_level": "not-a-level",
+                },
+            ],
         }
         with pytest.raises(WorkerOutputError, match="Unknown ObservabilityLevel"):
-            deserialize_worker_data(data=payload)
+            deserialize_report_data(data=payload, report_nodeid="n")
 
 
 class TestDeserializationSecurity:
     def test_strips_ansi_from_summary(self) -> None:
         payload: dict[str, Any] = {
             "schema": SCHEMA_VERSION,
-            "results_by_nodeid": {
-                "n": [
-                    {
-                        "safe": False,
-                        "status": "unsafe",
-                        "summary": "\x1b[31mDANGER\x1b[0m",
-                        "observability_level": "response_only",
-                    },
-                ],
-            },
+            "nodeid": "n",
+            "results": [
+                {
+                    "safe": False,
+                    "status": "unsafe",
+                    "summary": "\x1b[31mDANGER\x1b[0m",
+                    "observability_level": "response_only",
+                },
+            ],
         }
-        result = deserialize_worker_data(data=payload)["n"][0]
+        result = _deserialize_report_results(data=payload)["n"][0]
         assert result.summary == "DANGER"
         assert "\x1b" not in result.summary
 
     def test_strips_ansi_from_response_text(self) -> None:
         payload: dict[str, Any] = {
             "schema": SCHEMA_VERSION,
-            "results_by_nodeid": {
-                "n": [
-                    {
-                        "safe": True,
-                        "status": "safe",
-                        "summary": "x",
-                        "observability_level": "response_only",
-                        "turns": [
-                            {
-                                "request": {"prompt": "p"},
-                                "response": {"text": "\x1b[31mDANGER\x1b[0m"},
-                            },
-                        ],
-                    },
-                ],
-            },
+            "nodeid": "n",
+            "results": [
+                {
+                    "safe": True,
+                    "status": "safe",
+                    "summary": "x",
+                    "observability_level": "response_only",
+                    "turns": [
+                        {
+                            "request": {"prompt": "p"},
+                            "response": {"text": "\x1b[31mDANGER\x1b[0m"},
+                        },
+                    ],
+                },
+            ],
         }
-        result = deserialize_worker_data(data=payload)["n"][0]
+        result = _deserialize_report_results(data=payload)["n"][0]
         assert result.turns[0].response.text == "DANGER"
 
     def test_nan_inf_in_duration_coerced_to_zero(self) -> None:
@@ -487,44 +523,43 @@ class TestDeserializationSecurity:
                 "n": [_make_result(duration_seconds=float("nan"))],
             },
         )
-        payload = serialize_worker_data(session=session)
+        payload = _serialize_session_results(session=session)
         encoded = json.dumps(payload, default=str)
         assert "NaN" not in encoded
-        recovered = deserialize_worker_data(data=payload)
+        recovered = _deserialize_report_results(data=payload)
         assert math.isfinite(recovered["n"][0].duration_seconds)
 
     def test_payload_artifact_path_preserved_in_metadata(self) -> None:
         payload: dict[str, Any] = {
             "schema": SCHEMA_VERSION,
-            "results_by_nodeid": {
-                "n": [
-                    {
-                        "safe": True,
-                        "status": "safe",
-                        "summary": "x",
-                        "observability_level": "response_only",
-                        "turns": [
-                            {
-                                "request": {
-                                    "prompt": None,
-                                    "attachments": [
-                                        {
-                                            "content": "c",
-                                            "id": "p1",
-                                            "format": "pdf",
-                                            "artifact": "/worker/local/path.pdf",
-                                            "metadata": {},
-                                        },
-                                    ],
-                                },
-                                "response": {"text": "ok"},
+            "nodeid": "n",
+            "results": [
+                {
+                    "safe": True,
+                    "status": "safe",
+                    "summary": "x",
+                    "observability_level": "response_only",
+                    "turns": [
+                        {
+                            "request": {
+                                "prompt": None,
+                                "attachments": [
+                                    {
+                                        "content": "c",
+                                        "id": "p1",
+                                        "format": "pdf",
+                                        "artifact": "/worker/local/path.pdf",
+                                        "metadata": {},
+                                    },
+                                ],
                             },
-                        ],
-                    },
-                ],
-            },
+                            "response": {"text": "ok"},
+                        },
+                    ],
+                },
+            ],
         }
-        result = deserialize_worker_data(data=payload)["n"][0]
+        result = _deserialize_report_results(data=payload)["n"][0]
         attachment = result.turns[0].request.attachments[0]
         assert attachment.format is PayloadFormat.TEXT
         assert attachment.artifact is None
@@ -542,7 +577,7 @@ class TestDeserializationSecurity:
         session = _make_session_with_results(
             results_by_nodeid={"n": [result]},
         )
-        payload = serialize_worker_data(session=session)
+        payload = _serialize_session_results(session=session)
         encoded = json.dumps(payload)
         decoded = json.loads(encoded)
         assert decoded["schema"] == SCHEMA_VERSION
@@ -560,8 +595,8 @@ class TestDeserializationSecurity:
             results_by_nodeid={"my::node": [result]},
         )
         with caplog.at_level(logging.WARNING):
-            payload = serialize_worker_data(session=session)
-        recovered = deserialize_worker_data(data=payload)
+            payload = _serialize_session_results(session=session)
+        recovered = _deserialize_report_results(data=payload)
         assert recovered["my::node"][0].metadata["obj"] == "<Obj>"
         assert any(
             "my::node" in record.getMessage() and "obj" in record.getMessage()
@@ -625,6 +660,15 @@ class TestMerge:
         assert report.metadata["incomplete"] is True
         assert "worker gw0 crashed" in report.metadata["incomplete_reasons"]
 
+    def test_mark_incomplete_deduplicates_reasons(self) -> None:
+        session = RampartSession()
+        session.mark_incomplete(reason="worker gw0 streamed a truncated Result")
+        session.mark_incomplete(reason="worker gw0 streamed a truncated Result")
+        report = session.build_report()
+        assert report.metadata["incomplete_reasons"] == [
+            "worker gw0 streamed a truncated Result",
+        ]
+
     def test_emitted_idempotency_flag(self) -> None:
         session = RampartSession()
         assert session.is_emitted is False
@@ -635,21 +679,31 @@ class TestMerge:
 class TestHandleTestnodedown:
     def test_records_incomplete_on_error(self) -> None:
         session = RampartSession()
+        session.merge_worker_results(
+            results_by_nodeid={"n": [_make_result(summary="already-streamed")]},
+        )
         node = MagicMock()
         node.gateway.id = "gw1"
         handle_testnodedown(
             session=session,
             node=node,
             error="boom",
+            received_result_count=1,
         )
         assert session.is_incomplete is True
+        assert session._results[0].summary == "already-streamed"
 
     def test_records_incomplete_on_missing_workeroutput(self) -> None:
         session = RampartSession()
         node = MagicMock()
         node.gateway.id = "gw1"
         node.workeroutput = None
-        handle_testnodedown(session=session, node=node, error=None)
+        handle_testnodedown(
+            session=session,
+            node=node,
+            error=None,
+            received_result_count=0,
+        )
         assert session.is_incomplete is True
 
     def test_records_incomplete_on_missing_rampart_key(self) -> None:
@@ -657,43 +711,97 @@ class TestHandleTestnodedown:
         node = MagicMock()
         node.gateway.id = "gw1"
         node.workeroutput = {}
-        handle_testnodedown(session=session, node=node, error=None)
+        handle_testnodedown(
+            session=session,
+            node=node,
+            error=None,
+            received_result_count=0,
+        )
         assert session.is_incomplete is True
+
+    def test_records_incomplete_on_legacy_workeroutput_key(self) -> None:
+        session = RampartSession()
+        node = MagicMock()
+        node.gateway.id = "gw1"
+        node.workeroutput = {
+            "rampart_xdist_v1": {
+                "schema": "rampart.xdist.v1",
+                "streamed_result_count": 0,
+            },
+        }
+        handle_testnodedown(
+            session=session,
+            node=node,
+            error=None,
+            received_result_count=0,
+        )
+        assert session.is_incomplete is True
+        assert session.incomplete_reasons == ["worker gw1 missing RAMPART output"]
 
     def test_records_incomplete_on_deserialization_failure(self) -> None:
         session = RampartSession()
         node = MagicMock()
         node.gateway.id = "gw1"
         node.workeroutput = {WORKEROUTPUT_KEY: {"schema": "wrong-version"}}
-        handle_testnodedown(session=session, node=node, error=None)
+        handle_testnodedown(
+            session=session,
+            node=node,
+            error=None,
+            received_result_count=0,
+        )
         assert session.is_incomplete is True
 
-    def test_records_incomplete_on_truncated_payload(self) -> None:
+    def test_records_incomplete_on_missing_streamed_count(self) -> None:
         session = RampartSession()
         node = MagicMock()
         node.gateway.id = "gw1"
         node.workeroutput = {
             WORKEROUTPUT_KEY: {
                 "schema": SCHEMA_VERSION,
-                "rampart_truncated": True,
+                "trial_specs": [],
             },
         }
-        handle_testnodedown(session=session, node=node, error=None)
+        handle_testnodedown(
+            session=session,
+            node=node,
+            error=None,
+            received_result_count=0,
+        )
         assert session.is_incomplete is True
 
-    def test_merges_results_on_success(self) -> None:
+    def test_records_incomplete_on_streamed_count_mismatch(self) -> None:
         session = RampartSession()
-        worker_session = _make_session_with_results(
-            results_by_nodeid={"n": [_make_result(summary="from-worker")]},
+        payload = serialize_worker_data(
+            session=RampartSession(),
+            streamed_result_count=2,
         )
-        payload = serialize_worker_data(session=worker_session)
         node = MagicMock()
         node.gateway.id = "gw1"
         node.workeroutput = {WORKEROUTPUT_KEY: payload}
-        handle_testnodedown(session=session, node=node, error=None)
+        handle_testnodedown(
+            session=session,
+            node=node,
+            error=None,
+            received_result_count=1,
+        )
+        assert session.is_incomplete is True
+
+    def test_accepts_matching_streamed_count(self) -> None:
+        session = RampartSession()
+        payload = serialize_worker_data(
+            session=RampartSession(),
+            streamed_result_count=2,
+        )
+        node = MagicMock()
+        node.gateway.id = "gw1"
+        node.workeroutput = {WORKEROUTPUT_KEY: payload}
+        handle_testnodedown(
+            session=session,
+            node=node,
+            error=None,
+            received_result_count=2,
+        )
         assert session.is_incomplete is False
-        assert len(session._results) == 1
-        assert session._results[0].summary == "from-worker"
 
     def test_merges_trial_specs_on_success(self) -> None:
         session = RampartSession()
@@ -708,11 +816,19 @@ class TestHandleTestnodedown:
             base_nodeid="test.py::test_x",
             threshold=0.8,
         )
-        payload = serialize_worker_data(session=worker_session)
+        payload = serialize_worker_data(
+            session=worker_session,
+            streamed_result_count=0,
+        )
         node = MagicMock()
         node.gateway.id = "gw1"
         node.workeroutput = {WORKEROUTPUT_KEY: payload}
-        handle_testnodedown(session=session, node=node, error=None)
+        handle_testnodedown(
+            session=session,
+            node=node,
+            error=None,
+            received_result_count=0,
+        )
         assert session.is_incomplete is False
         assert set(session.trial_specs) == {
             "test.py::test_x[trial-0]",
@@ -728,66 +844,93 @@ class TestHandleTestnodedown:
 
 
 class TestOrderingDeterminism:
-    def _payload_node(
+    def _streamed_report(
         self,
         *,
         worker_id: str,
         nodeid: str,
-        summary: str,
+        summaries: list[str],
     ) -> MagicMock:
-        worker_session = _make_session_with_results(
-            results_by_nodeid={nodeid: [_make_result(summary=summary)]},
+        payload = serialize_report_data(
+            config=_make_config(is_worker=True),
+            nodeid=nodeid,
+            results=[_make_result(summary=summary) for summary in summaries],
         )
-        payload = serialize_worker_data(session=worker_session)
-        node = MagicMock()
-        node.gateway.id = worker_id
-        node.workeroutput = {WORKEROUTPUT_KEY: payload}
-        return node
+        report = MagicMock()
+        report.nodeid = nodeid
+        report.worker_id = worker_id
+        setattr(report, REPORT_RESULTS_ATTR, payload)
+        return report
 
-    def _merge_order(self, nodes: list[MagicMock]) -> list[str]:
+    def _merge_order(self, reports: list[MagicMock]) -> list[str]:
         session = RampartSession()
-        for node in nodes:
-            handle_testnodedown(session=session, node=node, error=None)
+        for report in reports:
+            merge_report_results(session=session, report=report)
         return [r.metadata["_pytest_nodeid"] for r in session.build_report().results]
 
-    def test_report_order_independent_of_worker_completion_order(self) -> None:
-        node_a = self._payload_node(
+    def test_report_order_independent_of_arrival_order(self) -> None:
+        report_a = self._streamed_report(
             worker_id="gw0",
             nodeid="pkg/test_a.py::test_a",
-            summary="a",
+            summaries=["a"],
         )
-        node_z = self._payload_node(
+        report_z = self._streamed_report(
             worker_id="gw1",
             nodeid="pkg/test_z.py::test_z",
-            summary="z",
+            summaries=["z"],
         )
-        forward = self._merge_order([node_a, node_z])
-        reverse = self._merge_order([node_z, node_a])
+        forward = self._merge_order([report_a, report_z])
+        reverse = self._merge_order([report_z, report_a])
         assert forward == reverse
         assert forward == ["pkg/test_a.py::test_a", "pkg/test_z.py::test_z"]
 
     def test_deserialize_sets_authoritative_nodeid_and_index(self) -> None:
-        worker_session = _make_session_with_results(
-            results_by_nodeid={
-                "pkg::t": [_make_result(summary="a"), _make_result(summary="b")],
-            },
+        payload = serialize_report_data(
+            config=_make_config(is_worker=True),
+            nodeid="pkg::t",
+            results=[_make_result(summary="a"), _make_result(summary="b")],
         )
-        payload = serialize_worker_data(session=worker_session)
-        results = deserialize_worker_data(data=payload)["pkg::t"]
+        results_by_nodeid, _ = deserialize_report_data(
+            data=payload,
+            report_nodeid="pkg::t",
+        )
+        results = results_by_nodeid["pkg::t"]
         assert [r.metadata["_pytest_nodeid"] for r in results] == ["pkg::t", "pkg::t"]
         assert [r.metadata["_rampart_result_index"] for r in results] == [0, 1]
 
-    def test_handle_testnodedown_tags_source_worker(self) -> None:
-        worker_session = _make_session_with_results(
-            results_by_nodeid={"n": [_make_result(summary="x")]},
+    def test_incremental_merge_tags_source_worker(self) -> None:
+        report = self._streamed_report(
+            worker_id="gw3",
+            nodeid="n",
+            summaries=["x"],
         )
-        payload = serialize_worker_data(session=worker_session)
-        node = MagicMock()
-        node.gateway.id = "gw3"
-        node.workeroutput = {WORKEROUTPUT_KEY: payload}
         session = RampartSession()
-        handle_testnodedown(session=session, node=node, error=None)
+        merge_report_results(session=session, report=report)
         assert session._results[0].metadata["_rampart_source_worker"] == "gw3"
+
+    def test_dist_each_keeps_worker_and_result_order_total(self) -> None:
+        report_gw1 = self._streamed_report(
+            worker_id="gw1",
+            nodeid="n",
+            summaries=["gw1-0", "gw1-1"],
+        )
+        report_gw0 = self._streamed_report(
+            worker_id="gw0",
+            nodeid="n",
+            summaries=["gw0-0", "gw0-1"],
+        )
+        session = RampartSession()
+        merge_report_results(session=session, report=report_gw1)
+        merge_report_results(session=session, report=report_gw0)
+        report = session.build_report()
+        order = [
+            (
+                result.metadata["_rampart_result_index"],
+                result.metadata["_rampart_source_worker"],
+            )
+            for result in report.results
+        ]
+        assert order == [(0, "gw0"), (0, "gw1"), (1, "gw0"), (1, "gw1")]
 
 
 class TestTrialSpecs:
@@ -803,7 +946,10 @@ class TestTrialSpecs:
             base_nodeid="t.py::a",
             threshold=0.75,
         )
-        payload = serialize_worker_data(session=session)
+        payload = serialize_worker_data(
+            session=session,
+            streamed_result_count=2,
+        )
 
         # Payload must survive a JSON round-trip (xdist transports JSON).
         decoded = json.loads(json.dumps(payload))
@@ -816,13 +962,15 @@ class TestTrialSpecs:
 
     def test_payload_without_trials_returns_empty_dict(self) -> None:
         session = RampartSession()
-        payload = serialize_worker_data(session=session)
+        payload = serialize_worker_data(
+            session=session,
+            streamed_result_count=0,
+        )
         assert deserialize_trial_specs(data=payload) == {}
 
     def test_skips_malformed_entries(self) -> None:
         data: dict[str, Any] = {
             "schema": SCHEMA_VERSION,
-            "results_by_nodeid": {},
             "trial_specs": [
                 {"clone_nodeid": "ok", "base_nodeid": "b", "threshold": 0.5},
                 "not-a-dict",
@@ -838,7 +986,6 @@ class TestTrialSpecs:
     def test_clamps_non_finite_threshold(self) -> None:
         data: dict[str, Any] = {
             "schema": SCHEMA_VERSION,
-            "results_by_nodeid": {},
             "trial_specs": [
                 {"clone_nodeid": "a", "base_nodeid": "b", "threshold": float("inf")},
                 {"clone_nodeid": "c", "base_nodeid": "d", "threshold": float("nan")},
@@ -876,35 +1023,116 @@ class TestFinalizeWorker:
         workeroutput: dict[str, Any] = {}
         config.workeroutput = workeroutput
         session = RampartSession()
-        finalize_worker(config=config, session=session)
+        finalize_worker(
+            config=config,
+            session=session,
+            streamed_result_count=0,
+        )
         assert WORKEROUTPUT_KEY not in workeroutput
 
-    def test_writes_workeroutput_on_worker(self) -> None:
+    def test_writes_slim_workeroutput_on_worker(self) -> None:
         config = _make_config(is_worker=True)
         workeroutput: dict[str, Any] = {}
         config.workeroutput = workeroutput
         session = _make_session_with_results(
             results_by_nodeid={"n": [_make_result(summary="x")]},
         )
-        finalize_worker(config=config, session=session)
+        finalize_worker(
+            config=config,
+            session=session,
+            streamed_result_count=1,
+        )
         assert WORKEROUTPUT_KEY in workeroutput
         payload: dict[str, Any] = workeroutput[WORKEROUTPUT_KEY]
         assert payload["schema"] == SCHEMA_VERSION
-        assert "results_by_nodeid" in payload
+        assert payload["streamed_result_count"] == 1
+        assert "results_by_nodeid" not in payload
+        assert "results" not in payload
 
-    def test_truncates_oversize_payload(
-        self,
-    ) -> None:
-        config = _make_config(is_worker=True, max_bytes=1)
-        workeroutput: dict[str, Any] = {}
-        config.workeroutput = workeroutput
-        session = _make_session_with_results(
-            results_by_nodeid={"n": [_make_result()]},
+
+class TestReportEnvelope:
+    def test_attaches_execnet_safe_round_trip(self) -> None:
+        report = MagicMock()
+        report.nodeid = "test.py::test_x"
+        results = [_make_result(summary="one"), _make_result(summary="two")]
+        count = attach_report_results(
+            config=_make_config(is_worker=True),
+            report=report,
+            results=results,
         )
-        with pytest.raises(SizeLimitError):
-            finalize_worker(config=config, session=session)
-        payload: dict[str, Any] = workeroutput[WORKEROUTPUT_KEY]
-        assert payload.get("rampart_truncated") is True
+        encoded = json.dumps(getattr(report, REPORT_RESULTS_ATTR))
+        decoded = json.loads(encoded)
+        recovered, truncated = deserialize_report_data(
+            data=decoded,
+            report_nodeid=report.nodeid,
+        )
+        assert count == 2
+        assert [result.summary for result in recovered[report.nodeid]] == [
+            "one",
+            "two",
+        ]
+        assert truncated is False
+
+    def test_oversized_result_is_localized_and_marks_incomplete(self) -> None:
+        payload = serialize_report_data(
+            config=_make_config(is_worker=True, max_bytes=1024),
+            nodeid="n",
+            results=[
+                _make_result(summary="normal"),
+                _make_result(
+                    summary="x" * 10_000,
+                    harm_category="custom-risk",
+                    metadata={"_pytest_test_name": "test_oversized"},
+                ),
+            ],
+        )
+        report = MagicMock()
+        report.nodeid = "n"
+        report.worker_id = "gw0"
+        setattr(report, REPORT_RESULTS_ATTR, payload)
+        session = RampartSession()
+        merged = merge_report_results(session=session, report=report)
+        assert merged == ("gw0", 2)
+        assert [result.summary for result in session._results[:1]] == ["normal"]
+        assert session._results[1].status is SafetyStatus.ERROR
+        assert session._results[1].harm_category == "custom-risk"
+        assert session._results[1].metadata["_pytest_test_name"] == "test_oversized"
+        assert session._results[1].metadata["_pytest_nodeid"] == "n"
+        assert session._results[1].metadata["_rampart_transport_truncated"] is True
+        marker = payload["results"][1]
+        assert len(json.dumps(marker).encode("utf-8")) <= MIN_RESULT_SIZE_LIMIT_BYTES
+        assert marker["metadata"]["_rampart_limit_bytes"] == MIN_RESULT_SIZE_LIMIT_BYTES
+        assert session.is_incomplete is True
+
+    @pytest.mark.parametrize(
+        "escaped",
+        ["\x00" * 10_000, "\U0001f600" * 10_000],
+        ids=["control", "non-bmp"],
+    )
+    def test_minimum_cap_contains_escaped_attribution(self, escaped: str) -> None:
+        payload = serialize_report_data(
+            config=_make_config(is_worker=True, max_bytes=1),
+            nodeid=escaped,
+            results=[
+                _make_result(
+                    summary="x" * 10_000,
+                    harm_category=escaped,
+                    metadata={"_pytest_test_name": escaped},
+                ),
+            ],
+        )
+        marker = payload["results"][0]
+        assert len(json.dumps(marker).encode("utf-8")) <= MIN_RESULT_SIZE_LIMIT_BYTES
+        assert len(json.dumps(marker["harm_category"]).encode("utf-8")) <= 512
+        assert (
+            len(
+                json.dumps(marker["metadata"]["_pytest_test_name"]).encode("utf-8"),
+            )
+            <= 512
+        )
+        assert (
+            len(json.dumps(marker["metadata"]["_pytest_nodeid"]).encode("utf-8")) <= 512
+        )
 
 
 class TestSinkDiscovery:
@@ -1075,11 +1303,11 @@ class TestConstants:
     def test_default_size_limit_is_64mb(self) -> None:
         assert DEFAULT_SIZE_LIMIT_BYTES == 64 * 1024 * 1024
 
-    def test_schema_version_is_v1(self) -> None:
-        assert SCHEMA_VERSION == "rampart.xdist.v1"
+    def test_schema_version_is_v2(self) -> None:
+        assert SCHEMA_VERSION == "rampart.xdist.v2"
 
     def test_workeroutput_key_namespaced(self) -> None:
-        assert WORKEROUTPUT_KEY.startswith("rampart_xdist")
+        assert WORKEROUTPUT_KEY == "rampart_xdist_v2"
 
 
 class TestTestRunReportTestable:

--- a/tests/unit/pytest_plugin/test_xdist_aggregation.py
+++ b/tests/unit/pytest_plugin/test_xdist_aggregation.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from rampart.pytest_plugin._xdist import MIN_RESULT_SIZE_LIMIT_BYTES
+
 if TYPE_CHECKING:
     from _pytest.pytester import Pytester, RunResult
 
@@ -81,6 +83,14 @@ def _load_reports(configured_pytester: Pytester) -> list[dict[str, Any]]:
         return []
     return [
         json.loads(p.read_text()) for p in sorted(out_dir.glob("run_report_*.json"))
+    ]
+
+
+def _report_results(report: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        result
+        for results in report.get("by_harm_category", {}).values()
+        for result in results
     ]
 
 
@@ -171,6 +181,177 @@ class TestXdistConsolidation:
         assert report["population_summary"]["total_runs"] == 4
         assert report["population_summary"]["safe_count"] == 3
         assert report["population_summary"]["unsafe_count"] == 1
+
+
+class TestStreamedResultTransport:
+    def test_async_test_body_streams_result(
+        self,
+        configured_pytester: Pytester,
+    ) -> None:
+        configured_pytester.makepyfile(
+            test_async_stream="""
+            import asyncio
+            import pytest
+            from rampart import record_result
+            from rampart.core.result import Result, SafetyStatus
+
+            @pytest.mark.asyncio
+            @pytest.mark.harm("async")
+            async def test_async_stream():
+                await asyncio.gather(asyncio.sleep(0), asyncio.sleep(0))
+                record_result(Result(status=SafetyStatus.SAFE, summary="async"))
+            """,
+        )
+        result = configured_pytester.runpytest(
+            "-p",
+            "no:cacheprovider",
+            "-n",
+            "1",
+        )
+        result.assert_outcomes(passed=1)
+        reports = _load_reports(configured_pytester)
+        assert reports[0]["total_runs"] == 1
+        assert _report_results(reports[0])[0]["summary"] == "async"
+
+    def test_teardown_only_result_is_intentionally_not_streamed(
+        self,
+        configured_pytester: Pytester,
+    ) -> None:
+        configured_pytester.makepyfile(
+            test_teardown_boundary="""
+            import pytest
+            from rampart import record_result
+            from rampart.core.result import Result, SafetyStatus
+
+            @pytest.fixture
+            def record_during_teardown():
+                yield
+                record_result(Result(
+                    status=SafetyStatus.SAFE,
+                    summary="teardown-only",
+                ))
+
+            @pytest.mark.harm("teardown")
+            def test_teardown_boundary(record_during_teardown):
+                pass
+            """,
+        )
+        result = configured_pytester.runpytest(
+            "-p",
+            "no:cacheprovider",
+            "-n",
+            "1",
+        )
+        result.assert_outcomes(passed=1)
+        reports = _load_reports(configured_pytester)
+        assert reports[0]["total_runs"] == 0
+        assert reports[0]["metadata"].get("incomplete") is not True
+
+    def test_dist_each_preserves_source_worker_separation(
+        self,
+        configured_pytester: Pytester,
+    ) -> None:
+        configured_pytester.makepyfile(
+            test_each="""
+            import pytest
+            from rampart import record_result
+            from rampart.core.result import Result, SafetyStatus
+
+            @pytest.mark.harm("each")
+            def test_each():
+                record_result(Result(status=SafetyStatus.SAFE, summary="each"))
+            """,
+        )
+        result = configured_pytester.runpytest(
+            "-p",
+            "no:cacheprovider",
+            "-n",
+            "2",
+            "--dist",
+            "each",
+        )
+        result.assert_outcomes(passed=2)
+        reports = _load_reports(configured_pytester)
+        streamed = _report_results(reports[0])
+        assert reports[0]["total_runs"] == 2
+        assert [item["metadata"]["_rampart_source_worker"] for item in streamed] == [
+            "gw0",
+            "gw1",
+        ]
+
+    def test_worker_crash_keeps_previously_streamed_result(
+        self,
+        configured_pytester: Pytester,
+    ) -> None:
+        configured_pytester.makepyfile(
+            test_crash="""
+            import os
+            import pytest
+            from rampart import record_result
+            from rampart.core.result import Result, SafetyStatus
+
+            @pytest.mark.harm("crash")
+            def test_0_stream_before_crash():
+                record_result(Result(
+                    status=SafetyStatus.SAFE,
+                    summary="survived",
+                ))
+
+            def test_1_crash_worker():
+                os._exit(3)
+            """,
+        )
+        configured_pytester.runpytest(
+            "-p",
+            "no:cacheprovider",
+            "-n",
+            "1",
+            "--max-worker-restart=0",
+        )
+        reports = _load_reports(configured_pytester)
+        assert reports[0]["total_runs"] == 1
+        assert _report_results(reports[0])[0]["summary"] == "survived"
+        assert reports[0]["metadata"]["incomplete"] is True
+
+    def test_oversized_result_does_not_drop_normal_result(
+        self,
+        configured_pytester: Pytester,
+    ) -> None:
+        configured_pytester.makepyfile(
+            test_cap="""
+            import pytest
+            from rampart import record_result
+            from rampart.core.result import Result, SafetyStatus
+
+            @pytest.mark.harm("cap")
+            def test_0_normal():
+                record_result(Result(status=SafetyStatus.SAFE, summary="normal"))
+
+            @pytest.mark.harm("cap")
+            def test_1_oversized():
+                record_result(Result(
+                    status=SafetyStatus.SAFE,
+                    summary="x" * 5000,
+                ))
+            """,
+        )
+        result = configured_pytester.runpytest(
+            "-p",
+            "no:cacheprovider",
+            "-n",
+            "1",
+            "--rampart-xdist-max-bytes=1024",
+        )
+        result.assert_outcomes(passed=2)
+        reports = _load_reports(configured_pytester)
+        streamed = _report_results(reports[0])
+        assert reports[0]["total_runs"] == 2
+        assert any(item["summary"] == "normal" for item in streamed)
+        assert any(
+            item["metadata"].get("_rampart_transport_truncated") is True
+            for item in streamed
+        )
+        assert reports[0]["metadata"]["incomplete"] is True
 
 
 class TestXdistTrialAggregation:
@@ -306,18 +487,31 @@ class TestXdistMetadata:
         assert "population_summary" in reports[0]
 
     def test_size_cap_marks_run_incomplete(self, configured_pytester: Pytester) -> None:
-        """Forcing a 1-byte cap surfaces incompleteness in report metadata.
+        """An oversized Result surfaces incompleteness in report metadata.
 
         Triggers the truncation path so the controller must record
         ``incomplete=True`` plus a reason in the merged report.
         """
-        _setup_simple_tests(configured_pytester)
+        configured_pytester.makepyfile(
+            test_size_cap="""
+            import pytest
+            from rampart import record_result
+            from rampart.core.result import Result, SafetyStatus
+
+            @pytest.mark.harm("cap")
+            def test_oversized():
+                record_result(Result(
+                    status=SafetyStatus.SAFE,
+                    summary="x" * 10_000,
+                ))
+            """,
+        )
         configured_pytester.runpytest(
             "-p",
             "no:cacheprovider",
             "-n",
-            "2",
-            "--rampart-xdist-max-bytes=1",
+            "1",
+            f"--rampart-xdist-max-bytes={MIN_RESULT_SIZE_LIMIT_BYTES}",
         )
         reports = _load_reports(configured_pytester)
         assert len(reports) == 1

--- a/tests/unit/pytest_plugin/test_xdist_aggregation.py
+++ b/tests/unit/pytest_plugin/test_xdist_aggregation.py
@@ -213,6 +213,114 @@ class TestStreamedResultTransport:
         assert reports[0]["total_runs"] == 1
         assert _report_results(reports[0])[0]["summary"] == "async"
 
+    def test_setup_failure_streams_result(
+        self,
+        configured_pytester: Pytester,
+    ) -> None:
+        configured_pytester.makepyfile(
+            test_setup_failure="""
+            import pytest
+            from rampart import record_result
+            from rampart.core.result import Result, SafetyStatus
+
+            @pytest.fixture
+            def failing_setup():
+                record_result(Result(
+                    status=SafetyStatus.ERROR,
+                    summary="setup-failed",
+                ))
+                raise RuntimeError("setup failed")
+
+            @pytest.mark.harm("setup")
+            def test_setup_failure(failing_setup):
+                pass
+            """,
+        )
+        result = configured_pytester.runpytest(
+            "-p",
+            "no:cacheprovider",
+            "-n",
+            "1",
+        )
+        result.assert_outcomes(errors=1)
+        reports = _load_reports(configured_pytester)
+        assert [item["summary"] for item in _report_results(reports[0])] == [
+            "setup-failed",
+        ]
+
+    def test_setup_skip_streams_result(
+        self,
+        configured_pytester: Pytester,
+    ) -> None:
+        configured_pytester.makepyfile(
+            test_setup_skip="""
+            import pytest
+            from rampart import record_result
+            from rampart.core.result import Result, SafetyStatus
+
+            @pytest.fixture
+            def skipped_setup():
+                record_result(Result(
+                    status=SafetyStatus.UNDETERMINED,
+                    summary="setup-skipped",
+                ))
+                pytest.skip("setup skipped")
+
+            @pytest.mark.harm("setup")
+            def test_setup_skip(skipped_setup):
+                pass
+            """,
+        )
+        result = configured_pytester.runpytest(
+            "-p",
+            "no:cacheprovider",
+            "-n",
+            "1",
+        )
+        result.assert_outcomes(skipped=1)
+        reports = _load_reports(configured_pytester)
+        assert [item["summary"] for item in _report_results(reports[0])] == [
+            "setup-skipped",
+        ]
+
+    def test_successful_setup_and_call_stream_once(
+        self,
+        configured_pytester: Pytester,
+    ) -> None:
+        configured_pytester.makepyfile(
+            test_setup_success="""
+            import pytest
+            from rampart import record_result
+            from rampart.core.result import Result, SafetyStatus
+
+            @pytest.fixture
+            def recorded_setup():
+                record_result(Result(
+                    status=SafetyStatus.SAFE,
+                    summary="setup",
+                ))
+
+            @pytest.mark.harm("setup")
+            def test_setup_success(recorded_setup):
+                record_result(Result(
+                    status=SafetyStatus.SAFE,
+                    summary="call",
+                ))
+            """,
+        )
+        result = configured_pytester.runpytest(
+            "-p",
+            "no:cacheprovider",
+            "-n",
+            "1",
+        )
+        result.assert_outcomes(passed=1)
+        reports = _load_reports(configured_pytester)
+        assert [item["summary"] for item in _report_results(reports[0])] == [
+            "setup",
+            "call",
+        ]
+
     def test_teardown_only_result_is_intentionally_not_streamed(
         self,
         configured_pytester: Pytester,

--- a/tests/unit/pytest_plugin/test_xdist_aggregation.py
+++ b/tests/unit/pytest_plugin/test_xdist_aggregation.py
@@ -197,7 +197,7 @@ class TestStreamedResultTransport:
 
             @pytest.mark.asyncio
             @pytest.mark.harm("async")
-            async def test_async_stream():
+            async def test_async_stream_async():
                 await asyncio.gather(asyncio.sleep(0), asyncio.sleep(0))
                 record_result(Result(status=SafetyStatus.SAFE, summary="async"))
             """,


### PR DESCRIPTION
## Description

The previous end-of-worker xdist batch could lose every Result from a worker that crashed before session finish and applied the size cap to the worker payload as a whole. This PR replaces that batch with incremental call-report streaming so the controller retains each Result as soon as its TestReport arrives.

This builds on the collector call-phase snapshot delivered by #152, which is now merged into `main`.

### Approach

- Workers attach an execnet-safe JSON envelope to call-phase TestReports using the existing full-fidelity Result serializer.
- The controller validates and merges envelopes in `pytest_runtest_logreport`, tags source workers, and preserves deterministic ordering, including `--dist=each`.
- Workeroutput contains only trial specifications and the expected streamed Result count. Node-down reconciliation marks missing output, missing counts, mismatches, and worker errors incomplete without discarding Results already received.
- The cap of 16 MiB applies independently to each Result. Oversized Results become attributed ERROR markers while normal Results continue to stream. A 4 KiB effective minimum and JSON-byte bounds guarantee markers fit, including control and non-BMP Unicode attribution.
- The transport schema and workeroutput key move to v2 so protocol skew fails closed.
- Results recorded only during fixture teardown remain intentionally outside the call-phase transport.

A killed worker retains every Result already delivered to the controller. The repository harness does not provide a deterministic remote/non-popen gateway, so that topology remains a residual integration risk.

### Validation

- `python -m pytest tests\unit\pytest_plugin -q` - 198 passed
- Focused streamed transport and real-xdist coverage - 95 passed
- Adversarial control/non-BMP cap coverage - 2 passed
- `ruff check .`
- `ruff format --check .`
- Repository-wide `ty check`


## Breaking changes

None. Mixed worker/controller transport versions remain unsupported and now fail closed under the v2 schema.

## Checklist

- [x] `pre-commit run --all-files` passes 
- [x] Tests added or updated for report streaming, async/call boundaries, slim workeroutput, reconciliation, crash durability, ordering, protocol skew, and per-Result caps
- [x] Documentation updated