### PR TITLE
[FIX]: Suppress intentional autouse fixture lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,8 +122,14 @@ ignore = [
 external = ["RMP001", "RMP002"]
 
 [tool.ruff.lint.per-file-ignores]
+"rampart/pytest_plugin/plugin.py" = [
+  "unused-noqa", # Ruff 0.16.4 does not recognize pytest-fixture-autouse.
+]
 "scripts/hatch_build.py" = [
   "implicit-namespace-package", # Top-level build hook
+]
+"tests/integration/conftest.py" = [
+  "unused-noqa", # Ruff 0.16.4 does not recognize pytest-fixture-autouse.
 ]
 "tools/flake8_rampart.py" = [
   "implicit-namespace-package", # flake8 imports it as a top-level module

--- a/rampart/pytest_plugin/plugin.py
+++ b/rampart/pytest_plugin/plugin.py
@@ -270,7 +270,7 @@ def trial_config(request: pytest.FixtureRequest) -> TrialConfig:
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # ruff: ignore[pytest-fixture-autouse]
 def _rampart_collect(  # pytest discovers this via autouse=True
     request: pytest.FixtureRequest,
 ) -> Generator[None, None, None]:

--- a/rampart/pytest_plugin/plugin.py
+++ b/rampart/pytest_plugin/plugin.py
@@ -270,7 +270,7 @@ def trial_config(request: pytest.FixtureRequest) -> TrialConfig:
     )
 
 
-@pytest.fixture(autouse=True)  # ruff: ignore[pytest-fixture-autouse]
+@pytest.fixture(autouse=True)  # ruff: ignore[pytest-fixture-autouse, unused-noqa]
 def _rampart_collect(  # pytest discovers this via autouse=True
     request: pytest.FixtureRequest,
 ) -> Generator[None, None, None]:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,7 +45,7 @@ _MODEL_VAR = "RAMPART_TEST_OPENAI_MODEL"
 _KEY_VAR = "RAMPART_TEST_OPENAI_KEY"
 
 
-@pytest_asyncio.fixture(scope="session", autouse=True)  # ruff: ignore[pytest-fixture-autouse]
+@pytest_asyncio.fixture(scope="session", autouse=True)  # ruff: ignore[pytest-fixture-autouse, unused-noqa]
 async def pyrit_session_async() -> None:
     """Initialize PyRIT in-memory once per session (autouse).
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,7 +45,7 @@ _MODEL_VAR = "RAMPART_TEST_OPENAI_MODEL"
 _KEY_VAR = "RAMPART_TEST_OPENAI_KEY"
 
 
-@pytest_asyncio.fixture(scope="session", autouse=True)
+@pytest_asyncio.fixture(scope="session", autouse=True)  # ruff: ignore[pytest-fixture-autouse]
 async def pyrit_session_async() -> None:
     """Initialize PyRIT in-memory once per session (autouse).
 


### PR DESCRIPTION
## Summary

- preserve the two intentionally autouse fixtures while suppressing Ruff 0.16.5's `pytest-fixture-autouse` diagnostic
- retain compatibility with `main`'s Ruff 0.16.4 by narrowly ignoring `unused-noqa` only in the affected files
- provide prerequisite remediation for Dependabot PR #182

## Validation

- `uv sync --all-extras --frozen`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run flake8`
- `uv run ty check`
- `uvx --from ruff==0.16.5 ruff check .`